### PR TITLE
Fix #1837 & Fix #1830

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -4,10 +4,12 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.utils.Utils;
 import org.jsoup.Connection.Response;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -23,7 +25,7 @@ import com.rarchives.ripme.utils.Http;
 public class EromeRipper extends AbstractHTMLRipper {
 
     boolean rippingProfile;
-
+    private HashMap<String, String> cookies = new HashMap<>();
 
     public EromeRipper (URL url) throws IOException {
         super(url);
@@ -31,12 +33,12 @@ public class EromeRipper extends AbstractHTMLRipper {
 
     @Override
     public String getDomain() {
-            return "erome.com";
+        return "erome.com";
     }
 
     @Override
     public String getHost() {
-            return "erome";
+        return "erome";
     }
 
     @Override
@@ -67,19 +69,19 @@ public class EromeRipper extends AbstractHTMLRipper {
 
     @Override
     public String getAlbumTitle(URL url) throws MalformedURLException {
-            try {
-                // Attempt to use album title as GID
-                Element titleElement = getFirstPage().select("meta[property=og:title]").first();
-                String title = titleElement.attr("content");
-                title = title.substring(title.lastIndexOf('/') + 1);
-                return getHost() + "_" + getGID(url) + "_" + title.trim();
-            } catch (IOException e) {
-                // Fall back to default album naming convention
-                LOGGER.info("Unable to find title at " + url);
-            } catch (NullPointerException e) {
-                return getHost() + "_" + getGID(url);
-            }
-            return super.getAlbumTitle(url);
+        try {
+            // Attempt to use album title as GID
+            Element titleElement = getFirstPage().select("meta[property=og:title]").first();
+            String title = titleElement.attr("content");
+            title = title.substring(title.lastIndexOf('/') + 1);
+            return getHost() + "_" + getGID(url) + "_" + title.trim();
+        } catch (IOException e) {
+            // Fall back to default album naming convention
+            LOGGER.info("Unable to find title at " + url);
+        } catch (NullPointerException e) {
+            return getHost() + "_" + getGID(url);
+        }
+        return super.getAlbumTitle(url);
     }
 
     @Override
@@ -96,9 +98,11 @@ public class EromeRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
+        this.setAuthCookie();
         Response resp = Http.url(this.url)
-                            .ignoreContentType()
-                            .response();
+                .cookies(cookies)
+                .ignoreContentType()
+                .response();
 
         return resp.parse();
     }
@@ -124,18 +128,18 @@ public class EromeRipper extends AbstractHTMLRipper {
     private List<String> getMediaFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         for (Element el : doc.select("img.img-front")) {
-			if (el.hasAttr("src")) {
-				if (el.attr("src").startsWith("https:")) {
-					results.add(el.attr("src"));
-				} else {
-					results.add("https:" + el.attr("src"));
-				}
-			} else if (el.hasAttr("data-src")) {
-				//to add images that are not loaded( as all images are lasyloaded as we scroll).
-				results.add(el.attr("data-src"));
-			}
+            if (el.hasAttr("src")) {
+                if (el.attr("src").startsWith("https:")) {
+                    results.add(el.attr("src"));
+                } else {
+                    results.add("https:" + el.attr("src"));
+                }
+            } else if (el.hasAttr("data-src")) {
+                //to add images that are not loaded( as all images are lasyloaded as we scroll).
+                results.add(el.attr("data-src"));
+            }
 
-		}
+        }
         for (Element el : doc.select("source[label=HD]")) {
             if (el.attr("src").startsWith("https:")) {
                 results.add(el.attr("src"));
@@ -152,7 +156,22 @@ public class EromeRipper extends AbstractHTMLRipper {
                 results.add("https:" + el.attr("src"));
             }
         }
+
+        if (results.size() == 0) {
+            if (cookies.isEmpty()) {
+                LOGGER.warn("You might try setting erome.laravel_session manually " +
+                        "if you think this page definitely contains media.");
+            }
+        }
+
         return results;
+    }
+
+    private void setAuthCookie() {
+        String sessionId = Utils.getConfigString("erome.laravel_session", null);
+        if (sessionId != null) {
+            cookies.put("laravel_session", sessionId);
+        }
     }
 
 }


### PR DESCRIPTION
# Category

* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed Xhamster Junit tests and fixed Erome Ripper to avoid JS-Browser-Check.
Added the following configuration option for `rip.properties`: `erome.laravel_session` which takes the `laravel_session`-cookie as value to avoid JS-Browser-Check on Erome. More info can be found here: https://github.com/RipMeApp/ripme/issues/1830#issuecomment-774848369

# Testing

* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
