### PR TITLE
Feature/no endless

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -24,9 +24,9 @@ import com.rarchives.ripme.ui.RipStatusMessage;
  */
 public abstract class AbstractHTMLRipper extends AbstractRipper {
     
-    private Map<URL, File> itemsPending = Collections.synchronizedMap(new HashMap<URL, File>());
-    private Map<URL, File> itemsCompleted = Collections.synchronizedMap(new HashMap<URL, File>());
-    private Map<URL, String> itemsErrored = Collections.synchronizedMap(new HashMap<URL, String>());
+    private final Map<URL, File> itemsPending = Collections.synchronizedMap(new HashMap<>());
+    private final Map<URL, File> itemsCompleted = Collections.synchronizedMap(new HashMap<>());
+    private final Map<URL, String> itemsErrored = Collections.synchronizedMap(new HashMap<>());
 
     protected AbstractHTMLRipper(URL url) throws IOException {
         super(url);
@@ -205,7 +205,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
      */
     private String fileNameFromURL(URL url) {
         String saveAs = url.toExternalForm();
-        if (saveAs.substring(saveAs.length() - 1) == "/") { saveAs = saveAs.substring(0,saveAs.length() - 1) ;}
+        if (saveAs.substring(saveAs.length() - 1).equals("/")) { saveAs = saveAs.substring(0,saveAs.length() - 1) ;}
         saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
         if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
         if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
@@ -291,16 +291,16 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
     }
 
     @Override
-    /**
-     * Returns total amount of files attempted.
+    /*
+      Returns total amount of files attempted.
      */
     public int getCount() {
         return itemsCompleted.size() + itemsErrored.size();
     }
 
     @Override
-    /**
-     * Queues multiple URLs of single images to download from a single Album URL
+    /*
+      Queues multiple URLs of single images to download from a single Album URL
      */
     public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
             // Only download one file if this is a test.
@@ -362,8 +362,8 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
     }
 
     @Override
-    /**
-     * Cleans up & tells user about successful download
+    /*
+      Cleans up & tells user about successful download
      */
     public void downloadCompleted(URL url, File saveAs) {
         if (observer == null) {
@@ -398,9 +398,9 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
     }
 
     @Override
-    /**
-     * Tells user that a single file in the album they wish to download has
-     * already been downloaded in the past.
+    /*
+      Tells user that a single file in the album they wish to download has
+      already been downloaded in the past.
      */
     public void downloadExists(URL url, File file) {
         if (observer == null) {
@@ -476,13 +476,12 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
      */
     @Override
     public String getStatusText() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(getCompletionPercentage())
-          .append("% ")
-          .append("- Pending: "  ).append(itemsPending.size())
-          .append(", Completed: ").append(itemsCompleted.size())
-          .append(", Errored: "  ).append(itemsErrored.size());
-        return sb.toString();
+        String sb = getCompletionPercentage() +
+                "% " +
+                "- Pending: " + itemsPending.size() +
+                ", Completed: " + itemsCompleted.size() +
+                ", Errored: " + itemsErrored.size();
+        return sb;
     }
 
 

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -6,10 +6,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jsoup.nodes.Document;
 
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
@@ -104,7 +106,15 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
             LOGGER.debug("Adding items from " + this.url + " to queue");
         }
 
+        List<String> doclocation = new ArrayList<>();
         while (doc != null) {
+
+            // catch if we saw a doc location already, save the ones seen in a list
+            if (doclocation.contains(doc.location())) {
+                break;
+            }
+            doclocation.add(doc.location());
+
             if (alreadyDownloadedUrls >= Utils.getConfigInteger("history.end_rip_after_already_seen", 1000000000) && !isThisATest()) {
                 sendUpdate(STATUS.DOWNLOAD_COMPLETE_HISTORY, "Already seen the last " + alreadyDownloadedUrls + " images ending rip");
                 break;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

there were multiple issues reported like #20 #21. the parent class for unit tests marks the run as test: https://github.com/ripmeapp2/ripme/blob/main/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RippersTest.java#L33. which then is taken into account in AbstractHTMLRipper to not test next pages: https://github.com/ripmeapp2/ripme/blob/main/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java#L168.

If this property is not tested, even the unit test would create an endless loop. Prevent this by remembering the URL.

while doing this, remove some of the warnings intellij idea gives.

# Testing

Required verification:
* [ x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
