### PR TITLE
Feature/xhamster paging

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -156,7 +156,7 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         if (!isVideoUrl(url)) {
             if (!doc.select("div.picture_view > div.pictures_block > div.items > div.item-container > a.item").isEmpty()) {
                 // Old HTML structure is still present at some places
-                for (Element page : doc.select("div.picture_view > div.pictures_block > div.items > div.item-container > a.item")) {
+                for (Element page : doc.select(".clearfix > div > a.slided")) {
                     // Make sure we don't waste time running the loop if the ripper has been stopped
                     if (isStopped()) {
                         break;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -139,7 +139,7 @@ public class XhamsterRipper extends AbstractHTMLRipper {
     @Override
     public Document getNextPage(Document doc) throws IOException {
         if (doc.select("a.prev-next-list-link").first() != null) {
-            String nextPageUrl = doc.select("a.prev-next-list-link").first().attr("href");
+            String nextPageUrl = doc.select("a.prev-next-list-link--next").first().attr("href");
             if (nextPageUrl.startsWith("http")) {
                 nextPageUrl = nextPageUrl.replaceAll("https?://\\w?\\w?\\.?xhamster([^<]*)\\.", "https://m.xhamster$1.");
                 return Http.url(nextPageUrl).get();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

reports like #20 #21 point out a problem with selecting and looping correctly. patch it a little. for the unit test case it does the right thing, so an improvement to before. at the end a red "null()" is reported - no idea where it comes from.

@mukulj77 reports correcting it here:
https://github.com/mukulj77/ripme/releases/tag/1.7.94-rc
but this does not merge cleanly into current "main" branch.

to find the issue i used intellij. i set break point to the unit test, and stepped through it. the debugger reveals the HTML "doc". on the other hand i used firefox web developer and pasted the ulr of the unit test into it. it told the CSS selector of an image. i tried variants of the selectors with the web developer console, like these ones:
```
$$('.clearfix > div > a.slided')
$$('a.prev-next-list-link')
$$('a.prev-next-list-link--next')
```
having never looked at xhamster pages before, and not beeing a web developer for me it was a first time. i'd be glad for hints how to do it better.


# Testing

Required verification:
* [x ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
