### PR TITLE
Disabling Vidble Unit Test

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
@@ -5,16 +5,20 @@ import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.VidbleRipper;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class VidbleRipperTest extends RippersTest {
     @Test
+    @Disabled("https://github.com/ripmeapp2/ripme/issues/51")
     public void testVidbleRip() throws IOException {
         VidbleRipper ripper = new VidbleRipper(new URL("http://www.vidble.com/album/y1oyh3zd"));
         testRipper(ripper);
     }
 
     @Test
+    @Disabled("https://github.com/ripmeapp2/ripme/issues/51")
     public void testGetGID() throws IOException {
         URL url = new URL("http://www.vidble.com/album/y1oyh3zd");
         VidbleRipper ripper = new VidbleRipper(url);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature
* [x] a fix according to unit tests


# Description

Issue: https://github.com/ripmeapp2/ripme/issues/51

I have disabled the Vidble Unit test because the website requires an authoritazion in order to see images.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
