### PR TITLE
Fix Vsco session token

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.Connection.Response;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
@@ -103,12 +104,12 @@ public class VscoRipper extends AbstractHTMLRipper {
         String userinfoPage = "https://vsco.co/content/Static/userinfo";
         String referer = "https://vsco.co/" + username + "/gallery";
         Map<String,String> cookies = new HashMap<>();
+        Map<String,String> responseCookies = new HashMap<>();
         cookies.put("vs_anonymous_id", UUID.randomUUID().toString());
         try {
-            Element doc = Http.url(userinfoPage).cookies(cookies).referrer(referer).ignoreContentType().get().body();
-            String json = doc.text().replaceAll("define\\(", "");
-            json = json.replaceAll("\\)", "");
-            return new JSONObject(json).getString("tkn");
+            Response resp = Http.url(userinfoPage).cookies(cookies).referrer(referer).ignoreContentType().response();
+            responseCookies = resp.cookies();
+            return responseCookies.get("vs");
         } catch (IOException e) {
             LOGGER.error("Could not get user tkn");
             return null;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix https://github.com/ripmeapp2/ripme/issues/58)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Issue: https://github.com/ripmeapp2/ripme/issues/58

Pulls the Vsco session token from the 'vs' cookie, rather than the 'tkn' json key.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
* [x] Downloads all relevant content.
* [x] Downloads content from multiple pages (as necessary or appropriate).
* [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
