### PR TITLE
Set workingDir even if the file exists - this prevents an NPE later

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -293,9 +293,9 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
         if (!Files.exists(wd)) {
             LOGGER.info("[+] Creating directory: " + Utils.removeCWD(wd));
             Files.createDirectory(wd);
-            this.workingDir = wd.toFile();
         }
-        LOGGER.debug("Set working directory to: " + this.workingDir);
+        this.workingDir = wd.toFile();
+        LOGGER.info("Set working directory to: {}", this.workingDir);
     }
 
     /**


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The workingDir is not set, when "re-ripping" is executed, which ends up with an NPE

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
