### PR TITLE
Automatically update the configuration when the value has been changed

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -500,9 +500,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configThreadsLabel = new JLabel(Utils.getLocalizedString("max.download.threads") + ":", JLabel.RIGHT);
         configTimeoutLabel = new JLabel(Utils.getLocalizedString("timeout.mill"), JLabel.RIGHT);
         configRetriesLabel = new JLabel(Utils.getLocalizedString("retry.download.count"), JLabel.RIGHT);
-        configThreadsText = new JTextField(Integer.toString(Utils.getConfigInteger("threads.size", 3)));
-        configTimeoutText = new JTextField(Integer.toString(Utils.getConfigInteger("download.timeout", 60000)));
-        configRetriesText = new JTextField(Integer.toString(Utils.getConfigInteger("download.retries", 3)));
+        configThreadsText = configField("threads.size", 3);
+        configTimeoutText = configField("download.timeout", 60000);
+        configRetriesText = configField("download.retries", 3);
         configOverwriteCheckbox = addNewCheckbox(Utils.getLocalizedString("overwrite.existing.files"), "file.overwrite",
                 false);
         configAutoupdateCheckbox = addNewCheckbox(Utils.getLocalizedString("auto.update"), "auto.update", true);
@@ -585,6 +585,39 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         pane.add(emptyPanel, gbc);
         gbc.weighty = 0;
         gbc.fill = GridBagConstraints.HORIZONTAL;
+    }
+
+    private JTextField configField(String key, int defaultValue) {
+        final var field = new JTextField(Integer.toString(Utils.getConfigInteger(key, defaultValue)));
+        field.getDocument().addDocumentListener(new DocumentListener() {
+
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                checkAndUpdate();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                checkAndUpdate();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                checkAndUpdate();
+            }
+
+            private void checkAndUpdate() {
+                final var txt = field.getText();
+                try {
+                    final var newValue = Integer.parseInt(txt);
+                    if (newValue>0) {
+                        Utils.setConfigInteger(key, newValue);
+                    }
+                } catch (final Exception e) {
+                }
+            }
+        });
+        return field;
     }
 
     private void addItemToConfigGridBagConstraints(GridBagConstraints gbc, int gbcYValue, JLabel thing1ToAdd,


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [X] a new feature


# Description

Currently, when you modify the configuration values in the ui, it's not updated, just when the window is closed, which was very surprising for me. Adding a document listener to the JTextFields ensure, that the latest/actual config is used by the rippers.


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
