### PR TITLE
Fix for IllegalArgumentException on pathing

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -322,7 +322,12 @@ public class Utils {
      * @return saveAs in relation to the CWD
      */
     public static String removeCWD(Path saveAs) {
-        return saveAs.relativize(Paths.get(".").toAbsolutePath()).toString();
+        try {
+            return saveAs.relativize(Paths.get(".").toAbsolutePath()).toString();
+        }
+        catch (IllegalArgumentException e) {
+            return saveAs.toString();
+        }
     }
 
     /**


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #73 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Tracked down the issue to the use of `relativize()` in the removeCWD method, but I'm not proficient enough in Java to go any further, so a try/catch block will work.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
