### PR TITLE
Fix VSCO Downloads

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -101,13 +101,10 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     private String getUserTkn(String username) {
-        String userinfoPage = "https://vsco.co/content/Static/userinfo";
-        String referer = "https://vsco.co/" + username + "/gallery";
-        Map<String,String> cookies = new HashMap<>();
+        String userTokenPage = "https://vsco.co/content/Static";
         Map<String,String> responseCookies = new HashMap<>();
-        cookies.put("vs_anonymous_id", UUID.randomUUID().toString());
         try {
-            Response resp = Http.url(userinfoPage).cookies(cookies).referrer(referer).ignoreContentType().response();
+            Response resp = Http.url(userTokenPage).ignoreContentType().response();
             responseCookies = resp.cookies();
             return responseCookies.get("vs");
         } catch (IOException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Closes #104 

VSCO no longer returns a `vs` cookie when a request is submitted to `https://vsco.co/content/Static/userinfo`. This cookie is required for subsequent requests for getting the list of user images. "https://vsco.co/content/Static" is a URL that returns a 200 code (even though it gives an HTML document that says error). Most importantly, it returns a header to set the `vs` cookie, with no request cookies required.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* * Tests that I did not modify are failing
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.