### PR TITLE
The same getFirstPage method is repeated everywhere

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -23,6 +23,7 @@ import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Utils;
 import com.rarchives.ripme.ui.MainWindow;
 import com.rarchives.ripme.ui.RipStatusMessage;
+import com.rarchives.ripme.utils.Http;
 
 /**
  * Simplified ripper, designed for ripping from sites by parsing HTML.
@@ -41,7 +42,9 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
     protected abstract String getDomain();
     public abstract String getHost();
 
-    protected abstract Document getFirstPage() throws IOException;
+    protected Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
 
     protected Document getCachedFirstPage() throws IOException {
         if (cachedFirstPage == null) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
@@ -63,11 +63,6 @@ public class AerisdiesRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
         Elements albumElements = page.select("div.imgbox > a > img");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
@@ -47,12 +47,6 @@ public class AllporncomicRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select(".wp-manga-chapter-img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -13,7 +13,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
 
 public class BatoRipper extends AbstractHTMLRipper {
 
@@ -94,11 +93,6 @@ public class BatoRipper extends AbstractHTMLRipper {
         return m.matches();
     }
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
 
     @Override
     public List<String> getURLsFromPage(Document doc) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BcfakesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BcfakesRipper.java
@@ -48,11 +48,6 @@ public class BcfakesRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         Elements hrefs = doc.select("a.next");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BlackbrickroadofozRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BlackbrickroadofozRipper.java
@@ -42,12 +42,6 @@ public class BlackbrickroadofozRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         sleep(1000);
         Element elem = doc.select("div[id=topnav] > nav.cc-nav > a.cc-next").first();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -2,7 +2,7 @@ package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ripper.rippers.ripperhelpers.ChanSite;
-import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
 import com.rarchives.ripme.utils.RipUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.rarchives.ripme.utils.Utils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
@@ -195,11 +194,9 @@ public class ChanRipper extends AbstractHTMLRipper {
         return this.url.getHost();
     }
 
-    @Override
     public Document getFirstPage() throws IOException {
-        return Http.url(this.url).get();
+        return super.getFirstPage();
     }
-
     private boolean isURLBlacklisted(String url) {
         for (String blacklist_item : url_piece_blacklist) {
             if (url.contains(blacklist_item)) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CyberdropRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CyberdropRipper.java
@@ -24,11 +24,6 @@ public class CyberdropRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    protected Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public String getDomain() {
         return "cyberdrop.me";
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
@@ -42,10 +42,6 @@ public class DribbbleRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         Elements hrefs = doc.select("a.next_page");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -81,11 +81,6 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(this.url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         String duckMoviesUrl = doc.select("iframe").attr("src");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DynastyscansRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DynastyscansRipper.java
@@ -43,12 +43,6 @@ public class DynastyscansRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         Element elem = doc.select("a[id=next_link]").first();
         if (elem == null || elem.attr("href").equals("#")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
@@ -49,11 +49,6 @@ public class ErofusRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         LOGGER.info(page);
         List<String> imageURLs = new ArrayList<>();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FemjoyhunterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FemjoyhunterRipper.java
@@ -42,12 +42,6 @@ public class FemjoyhunterRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FitnakedgirlsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FitnakedgirlsRipper.java
@@ -47,11 +47,6 @@ public class FitnakedgirlsRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
@@ -227,10 +227,6 @@ public class FlickrRipper extends AbstractHTMLRipper {
                         + " Got: " + url);
     }
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
 
     @Override
     public List<String> getURLsFromPage(Document doc) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FooktubeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FooktubeRipper.java
@@ -34,10 +34,6 @@ public class FooktubeRipper extends AbstractSingleFileRipper {
         return "mulemax.com";
     }
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
 
     @Override
     public boolean canRip(URL url) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
@@ -45,12 +45,6 @@ public class FreeComicOnlineRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-    
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         String nextPage = doc.select("div.select-pagination a").get(1).attr("href");
 	String nextUrl = "";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatporntubeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatporntubeRipper.java
@@ -41,12 +41,6 @@ public class GfycatporntubeRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         result.add(doc.select("source[id=mp4Source]").attr("src"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GirlsOfDesireRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GirlsOfDesireRipper.java
@@ -61,11 +61,6 @@ public class GirlsOfDesireRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("td.vtop > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaidudeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaidudeRipper.java
@@ -51,12 +51,6 @@ public class HentaidudeRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         Matcher m1 = p1.matcher(url.toString());

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoxRipper.java
@@ -42,12 +42,6 @@ public class HentaifoxRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         LOGGER.info(doc);
         List<String> result = new ArrayList<>();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
@@ -53,13 +53,6 @@ public class HentaiimageRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("div.icon-overlay > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HqpornerRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HqpornerRipper.java
@@ -64,8 +64,7 @@ public class HqpornerRipper extends AbstractHTMLRipper {
 
 	@Override
 	public Document getFirstPage() throws IOException {
-		// "url" is an instance field of the superclass
-		return Http.url(url).get();
+		return super.getFirstPage();
 	}
 
 	@Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HypnohubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HypnohubRipper.java
@@ -46,12 +46,6 @@ public class HypnohubRipper extends AbstractHTMLRipper {
                 "hypnohub.net/pool/show/ID - got " + url + " instead");
     }
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
     private String ripPost(String url) throws IOException {
         LOGGER.info(url);
         Document doc = Http.url(url).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
@@ -57,11 +57,6 @@ public class ImagebamRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         Elements hrefs = doc.select("a.pagination_current + a.pagination_link");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
@@ -56,11 +56,6 @@ public class ImagevenueRipper extends AbstractHTMLRipper {
                         + " Got: " + url);
     }
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("a[target=_blank]")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
@@ -41,10 +41,6 @@ public class ImgboxRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("div.boxed-content > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
@@ -56,12 +56,6 @@ public class JabArchivesRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         Elements hrefs = doc.select("a[title=\"Next page\"]");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JagodibujaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JagodibujaRipper.java
@@ -41,12 +41,6 @@ public class JagodibujaRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element comicPageUrl : doc.select("div.gallery-icon > a")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/KingcomixRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/KingcomixRipper.java
@@ -42,13 +42,6 @@ public class KingcomixRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("div.entry-content > p > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
@@ -37,10 +37,7 @@ public class LusciousRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        Document page = Http.url(url).get();
-        LOGGER.info("First page is " + url);
-        return page;
+        return super.getFirstPage();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
@@ -49,12 +49,6 @@ public class ManganeloRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         Element elem = doc.select("div.btn-navigation-chap > a.back").first();
         if (elem == null) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
@@ -50,11 +50,6 @@ public class MeituriRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         // Get number of images from the page

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ModelxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ModelxRipper.java
@@ -42,11 +42,6 @@ public class ModelxRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> result = new ArrayList<>();
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -86,8 +86,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
+        return super.getFirstPage();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaigalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaigalleryRipper.java
@@ -41,12 +41,6 @@ public class MyhentaigalleryRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select(".comic-thumb > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
@@ -42,12 +42,6 @@ public class MyreadingmangaRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("div * img[data-lazy-src]")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NatalieMuRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NatalieMuRipper.java
@@ -80,11 +80,6 @@ public class NatalieMuRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(this.url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
         Pattern p; Matcher m;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NfsfwRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NfsfwRipper.java
@@ -29,8 +29,6 @@ public class NfsfwRipper extends AbstractHTMLRipper {
             "https?://[wm.]*nfsfw.com/gallery/v/[^/]+/(.+)$"
     );
 
-    // cached first page
-    private Document fstPage;
     // threads pool for downloading images from image pages
     private DownloadThreadPool nfsfwThreadPool;
 
@@ -47,13 +45,6 @@ public class NfsfwRipper extends AbstractHTMLRipper {
     @Override
     public String getHost() {
         return HOST;
-    }
-
-    @Override
-    protected Document getFirstPage() throws IOException {
-        // cache the first page
-        this.fstPage = Http.url(url).get();
-        return fstPage;
     }
 
     @Override
@@ -157,9 +148,15 @@ public class NfsfwRipper extends AbstractHTMLRipper {
 
     @Override
     public boolean pageContainsAlbums(URL url) {
-        List<String> imageURLs = getImagePageURLs(fstPage);
-        List<String> subalbumURLs = getSubalbumURLs(fstPage);
-        return imageURLs.isEmpty() && !subalbumURLs.isEmpty();
+        try {
+            final var fstPage = getCachedFirstPage();
+            List<String> imageURLs = getImagePageURLs(fstPage);
+            List<String> subalbumURLs = getSubalbumURLs(fstPage);
+            return imageURLs.isEmpty() && !subalbumURLs.isEmpty();
+        } catch (IOException e) {
+            LOGGER.error("Unable to load " + url, e);
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -16,8 +16,6 @@ import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
 
 public class NudeGalsRipper extends AbstractHTMLRipper {
-    // Current HTML document
-    private Document albumDoc = null;
 
     public NudeGalsRipper(URL url) throws IOException {
         super(url);
@@ -48,14 +46,6 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
                 "Expected nude-gals.com gallery format: "
                         + "nude-gals.com/photoshoot.php?phtoshoot_id=####"
                         + " Got: " + url);
-    }
-
-    @Override
-    public Document getFirstPage() throws IOException {
-        if (albumDoc == null) {
-            albumDoc = Http.url(url).get();
-        }
-        return albumDoc;
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
@@ -47,12 +47,6 @@ public class OglafRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         if (doc.select("div#nav > a > div#nx").first() == null) {
             throw new IOException("No more pages");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
@@ -64,12 +64,6 @@ public class PichunterRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // We use comic-nav-next to the find the next page
         Element elem = doc.select("div.paperSpacings > ul > li.arrow").last();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
@@ -52,12 +52,6 @@ public class PicstatioRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         if (doc.select("a.next_page") != null) {
             return Http.url("https://www.picstatio.com" + doc.select("a.next_page").attr("href")).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
@@ -42,12 +42,6 @@ public class PorncomixRipper extends AbstractHTMLRipper {
         }
 
         @Override
-        public Document getFirstPage() throws IOException {
-            // "url" is an instance field of the superclass
-            return Http.url(url).get();
-        }
-
-        @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<>();
                 for (Element el : doc.select("div.single-post > div.gallery > dl > dt > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixinfoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixinfoRipper.java
@@ -42,12 +42,6 @@ public class PorncomixinfoRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
@@ -42,12 +42,6 @@ public class PornpicsRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("a.rel-link")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
@@ -41,11 +41,6 @@ public class RulePornRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         result.add(doc.select("source[type=video/mp4]").attr("src"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ShesFreakyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ShesFreakyRipper.java
@@ -12,7 +12,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
 
 public class ShesFreakyRipper extends AbstractHTMLRipper {
 
@@ -39,11 +38,6 @@ public class ShesFreakyRipper extends AbstractHTMLRipper {
         }
         throw new MalformedURLException("Expected shesfreaky.com URL format: "
                 + "shesfreaky.com/gallery/... - got " + url + "instead");
-    }
-
-    @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinfestRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinfestRipper.java
@@ -42,12 +42,6 @@ public class SinfestRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         Element elem = doc.select("td.style5 > a > img").last();
         LOGGER.info(elem.parent().attr("href"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SmuttyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SmuttyRipper.java
@@ -89,11 +89,6 @@ public class SmuttyRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SoundgasmRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SoundgasmRipper.java
@@ -43,7 +43,7 @@ public class SoundgasmRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
+        return super.getFirstPage();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SpankbangRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SpankbangRipper.java
@@ -29,11 +29,6 @@ public class SpankbangRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         Elements videos = doc.select(".video-js > source");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/StaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/StaRipper.java
@@ -48,12 +48,6 @@ public class StaRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("span > span > a.thumb")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TapasticRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TapasticRipper.java
@@ -47,11 +47,6 @@ public class TapasticRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> urls = new ArrayList<>();
         String html = page.data();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TeenplanetRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TeenplanetRipper.java
@@ -35,11 +35,6 @@ public class TeenplanetRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    protected Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     protected List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : page.select("#galleryImages > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ThechiveRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ThechiveRipper.java
@@ -71,12 +71,6 @@ public class ThechiveRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result;
         Matcher matcher = p1.matcher(url.toExternalForm());

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
@@ -42,12 +42,6 @@ public class TheyiffgalleryRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
-    @Override
     public Document getNextPage(Document doc) throws IOException {
         String nextPage = doc.select("span.navPrevNext > a").attr("href");
         if (nextPage != null && !nextPage.isEmpty() && nextPage.contains("start-")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VidbleRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VidbleRipper.java
@@ -46,11 +46,6 @@ public class VidbleRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         return getURLsFromPageStatic(doc);
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
@@ -61,12 +61,6 @@ public class ViewcomicRipper extends AbstractHTMLRipper {
         }
 
         @Override
-        public Document getFirstPage() throws IOException {
-            // "url" is an instance field of the superclass
-            return Http.url(url).get();
-        }
-
-        @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<String>();
                 for (Element el : doc.select("div.separator > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -216,11 +216,6 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -421,10 +421,4 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
 
 
     }
-
-    @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
@@ -45,11 +45,6 @@ public class XcartxRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
         Elements imageElements = page.select("div.f-desc img");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -106,13 +106,6 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         return m.matches();
     }
 
-
-    @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        return Http.url(url).get();
-    }
-
     @Override
     public boolean canRip(URL url) {
         Pattern p = Pattern.compile("^https?://([\\w\\w]*\\.)?xhamster([^<]*)\\.(com|one|desi)/photos/gallery/.*?(\\d+)$");
@@ -150,6 +143,11 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         }
         throw new IOException("No more pages");
 
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return super.getFirstPage();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -25,11 +25,6 @@ public class XvideosRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(this.url).get();
-    }
-
-    @Override
     public String getHost() {
         return HOST;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/YoupornRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/YoupornRipper.java
@@ -41,11 +41,6 @@ public class YoupornRipper extends AbstractSingleFileRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(this.url).get();
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         Elements videos = doc.select("video");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/YuvutuRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/YuvutuRipper.java
@@ -51,10 +51,6 @@ public class YuvutuRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-    }
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("div#galleria > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/tamindirmp3.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/tamindirmp3.java
@@ -41,12 +41,6 @@ public class tamindirmp3 extends AbstractHTMLRipper {
     }
 
     @Override
-    public Document getFirstPage() throws IOException {
-        return Http.url(url).get();
-
-    }
-
-    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> music = new ArrayList<>();
         for (Element el : doc.select("mp3")) {


### PR DESCRIPTION
Refactor code, to not repeat the same caching, getFirstPage implementation

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [X] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
