### PR TITLE
Create urls.txt before appending to it.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -336,7 +336,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");
             String text = url.toExternalForm() + System.lineSeparator();
             try {
-                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
                 itemsCompleted.put(url, urlFile);
             } catch (IOException e) {
                 LOGGER.error("Error while writing to " + urlFile, e);

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -165,7 +165,7 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");
             String text = url.toExternalForm() + System.lineSeparator();
             try {
-                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
                 itemsCompleted.put(url, urlFile);
             } catch (IOException e) {
                 LOGGER.error("Error while writing to " + urlFile, e);

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -74,7 +74,7 @@ public abstract class AlbumRipper extends AbstractRipper {
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");
             String text = url.toExternalForm() + System.lineSeparator();
             try {
-                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Files.write(urlFile, text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
                 itemsCompleted.put(url, urlFile);
             } catch (IOException e) {
                 LOGGER.error("Error while writing to " + urlFile, e);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

This adds the ability to create urls.txt before appending to that file, avoiding a NoSuchFileException being thrown when the option "Save URLs only" is selected.

Closes #114 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
