### PR TITLE
Fix imgur downloads

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -210,7 +210,7 @@ public class ImgurRipper extends AlbumRipper {
             if (Utils.getConfigBoolean("download.save_order", true)) {
                 saveAs.resolve(String.format("%03d_", index));
             }
-            saveAs.resolve(imgurImage.getSaveAs().replaceAll("\\?\\d", ""));
+            saveAs = saveAs.resolve(imgurImage.getSaveAs().replaceAll("\\?\\d", ""));
             addURLToDownload(imgurImage.url, saveAs);
         }
     }

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -323,7 +323,7 @@ public class Utils {
      */
     public static String removeCWD(Path saveAs) {
         try {
-            return saveAs.relativize(Paths.get(".").toAbsolutePath()).toString();
+            return Paths.get(".").toAbsolutePath().relativize(saveAs).toString();
         }
         catch (IllegalArgumentException e) {
             return saveAs.toString();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixes ability to write files downloaded from imgur to the correct location with their filename in a subfolder named after the post.

Closes #116 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
