### PR TITLE
Fixed ImagefapRipper.java

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -124,10 +124,16 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
         }
 
         List<String> doclocation = new ArrayList<>();
+
+        LOGGER.info("Got doc location " + doc.location());
+        
         while (doc != null) {
+
+            LOGGER.info("Processing a doc...");
 
             // catch if we saw a doc location already, save the ones seen in a list
             if (doclocation.contains(doc.location())) {
+                LOGGER.info("Already processed location " + doc.location() + " breaking");
                 break;
             }
             doclocation.add(doc.location());
@@ -136,6 +142,9 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
                 sendUpdate(STATUS.DOWNLOAD_COMPLETE_HISTORY, "Already seen the last " + alreadyDownloadedUrls + " images ending rip");
                 break;
             }
+
+            LOGGER.info("retrieving urls from doc");
+
             List<String> imageURLs = getURLsFromPage(doc);
             // If hasASAPRipping() returns true then the ripper will handle downloading the files
             // if not it's done in the following block of code


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fixes #127 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

* fixed ImagefapRipper.java to handle new URL schema
* added HTTP retries for transient network errors
* Additional logging in AbstractHTMLRipper

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors). <--- tests are currently broken
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
