### PR TITLE
Erome ripper does not download images fixed

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -126,17 +126,16 @@ public class EromeRipper extends AbstractHTMLRipper {
     private List<String> getMediaFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         for (Element el : doc.select("img.img-front")) {
-            if (el.hasAttr("src")) {
+            if (el.hasAttr("data-src")) {
+                //to add images that are not loaded( as all images are lasyloaded as we scroll).
+                results.add(el.attr("data-src"));
+            } else if (el.hasAttr("src")) {
                 if (el.attr("src").startsWith("https:")) {
                     results.add(el.attr("src"));
                 } else {
                     results.add("https:" + el.attr("src"));
                 }
-            } else if (el.hasAttr("data-src")) {
-                //to add images that are not loaded( as all images are lasyloaded as we scroll).
-                results.add(el.attr("data-src"));
             }
-
         }
         for (Element el : doc.select("source[label=HD]")) {
             if (el.attr("src").startsWith("https:")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fixes #123 and #133)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Erome ripper was not downloading the images as the HTML page structure changed at some point and the link to the image is no longer where the code expects it to be. I just rearranged the order of the checks and it is working now.

# Testing

Manual downloading multiple galleries