### PR TITLE
Update ImgboxRipper to set album title for folder

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
@@ -41,6 +41,18 @@ public class ImgboxRipper extends AbstractHTMLRipper {
     }
 
     @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        String title;
+        try {
+            title = Http.url(url).get().select("#gallery-view > h1").text();
+        }catch (Exception e){
+            LOGGER.info("[+] Failed to get album title, using id.");
+            title = getGID(url);
+        }
+        return "imgbox_" + title;
+    }
+
+    @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("div.boxed-content > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
@@ -46,7 +46,7 @@ public class ImgboxRipper extends AbstractHTMLRipper {
         try {
             title = Http.url(url).get().select("#gallery-view > h1").text();
         }catch (Exception e){
-            LOGGER.info("[+] Failed to get album title, using id.");
+            LOGGER.info("Failed to get album title, using id.");
             title = getGID(url);
         }
         return "imgbox_" + title;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #136 ) Not exactly a bug as it was never implemented but yes..
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature

# Description
Implemented the getAlbumTitle() method in ImgboxRipper to set album title for folder if it can get it and not use id by default. If the album title could not be fetched we fallback to the id. Kept the "imgbox_" prefix as it is the convention throughout the tool.

# Testing
Manual downloading multiple galleries