### PR TITLE
Add ability to skip downloads of files with specific extensions

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -343,6 +343,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
             return false;
         }
         if (shouldIgnoreURL(url)) {
+            sendUpdate(STATUS.DOWNLOAD_SKIP, "Skipping " + url.toExternalForm() + " - ignored extension");
             return false;
         }
         if (Utils.getConfigBoolean("urls_only.save", false)) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -342,6 +342,9 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
             LOGGER.info("[!] Skipping " + url + " -- already attempted: " + Utils.removeCWD(saveAs));
             return false;
         }
+        if (shouldIgnoreURL(url)) {
+            return false;
+        }
         if (Utils.getConfigBoolean("urls_only.save", false)) {
             // Output URL to file
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -161,6 +161,7 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
             return false;
         }
         if (shouldIgnoreURL(url)) {
+            sendUpdate(STATUS.DOWNLOAD_SKIP, "Skipping " + url.toExternalForm() + " - ignored extension");
             return false;
         }
         if (Utils.getConfigBoolean("urls_only.save", false)) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -160,6 +160,9 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
             LOGGER.info("[!] Skipping " + url + " -- already attempted: " + Utils.removeCWD(saveAs));
             return false;
         }
+        if (shouldIgnoreURL(url)) {
+            return false;
+        }
         if (Utils.getConfigBoolean("urls_only.save", false)) {
             // Output URL to file
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -699,4 +699,18 @@ public abstract class AbstractRipper
     protected boolean useByteProgessBar() { return false;}
     // If true ripme will try to resume a broken download for this ripper
     protected boolean tryResumeDownload() { return false;}
+
+    protected boolean shouldIgnoreURL(URL url) {
+        final String[] ignoredExtensions = Utils.getConfigStringArray("download.ignore_extensions");
+        if (ignoredExtensions == null || ignoredExtensions.length == 0) return false; // nothing ignored
+        String[] pathElements = url.getPath().split("\\.");
+        if (pathElements.length == 0) return false; // no extension, can't filter
+        String extension = pathElements[pathElements.length - 1];
+        for (String ignoredExtension : ignoredExtensions) {
+            if (ignoredExtension.equalsIgnoreCase(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -71,6 +71,7 @@ public abstract class AlbumRipper extends AbstractRipper {
             return false;
         }
         if (shouldIgnoreURL(url)) {
+            sendUpdate(STATUS.DOWNLOAD_SKIP, "Skipping " + url.toExternalForm() + " - ignored extension");
             return false;
         }
         if (Utils.getConfigBoolean("urls_only.save", false)) {

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -70,6 +70,9 @@ public abstract class AlbumRipper extends AbstractRipper {
             LOGGER.info("[!] Skipping " + url + " -- already attempted: " + Utils.removeCWD(saveAs));
             return false;
         }
+        if (shouldIgnoreURL(url)) {
+            return false;
+        }
         if (Utils.getConfigBoolean("urls_only.save", false)) {
             // Output URL to file
             Path urlFile = Paths.get(this.workingDir + "/urls.txt");

--- a/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
@@ -68,6 +68,9 @@ public abstract class VideoRipper extends AbstractRipper {
                 this.url = url;
                 return true;
             }
+            if (shouldIgnoreURL(url)) {
+                return false;
+            }
             threadPool.addThread(new DownloadVideoThread(url, saveAs, this));
         }
         return true;

--- a/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
@@ -69,6 +69,7 @@ public abstract class VideoRipper extends AbstractRipper {
                 return true;
             }
             if (shouldIgnoreURL(url)) {
+                sendUpdate(STATUS.DOWNLOAD_SKIP, "Skipping " + url.toExternalForm() + " - ignored extension");
                 return false;
             }
             threadPool.addThread(new DownloadVideoThread(url, saveAs, this));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -4,7 +4,8 @@ import com.rarchives.ripme.ripper.AbstractJSONRipper;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -23,7 +24,7 @@ import java.util.stream.Collectors;
  * <a href="https://coomer.su/api/schema">See this link for the API schema</a>.
  */
 public class CoomerPartyRipper extends AbstractJSONRipper {
-    private static final Logger LOGGER = Logger.getLogger(CoomerPartyRipper.class);
+    private static final Logger LOGGER = LogManager.getLogger(CoomerPartyRipper.class);
     private static final String IMG_URL_BASE = "https://c3.coomer.su/data";
     private static final String VID_URL_BASE = "https://c1.coomer.su/data";
     private static final Pattern IMG_PATTERN = Pattern.compile("^.*\\.(jpg|jpeg|png|gif|apng|webp|tif|tiff)$", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1435,6 +1435,11 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 appendLog((String) msg.getObject(), Color.ORANGE);
             }
             break;
+        case DOWNLOAD_SKIP:
+            if (LOGGER.isEnabled(Level.INFO)) {
+                appendLog((String) msg.getObject(), Color.YELLOW);
+            }
+            break;
 
         case RIP_ERRORED:
             if (LOGGER.isEnabled(Level.ERROR)) {

--- a/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
+++ b/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
@@ -13,6 +13,7 @@ public class RipStatusMessage {
         DOWNLOAD_COMPLETE_HISTORY("Download Complete History"),
         RIP_COMPLETE("Rip Complete"),
         DOWNLOAD_WARN("Download problem"),
+        DOWNLOAD_SKIP("Download Skipped"),
         TOTAL_BYTES("Total bytes"),
         COMPLETED_BYTES("Completed bytes"),
         RIP_ERRORED("Rip Errored"),

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -17,6 +17,9 @@ page.timeout = 5000
 # Maximum size of downloaded files in bytes (required)
 download.max_size = 104857600
 
+# Any URLs ending with one of these comma-separated values will be skipped
+#download.ignore_extensions = mp4,gif,m4v,webm,html
+
 # Don't retry on 404 errors
 error.skip404 = true
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Added an extra `rip.properties` key (`download.ignore_extensions`) with a CSV set of strings. If a download URL in any ripper matches any of these, the download is skipped and a log message is shown in the UI.

Side change - fixed an error with the logger in `CoomerPartyRipper`

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
