### PR TITLE
Patch/Bug fix for ContextMenuMouseListener Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,12 +135,14 @@ tasks.withType<AbstractArchiveTask>().configureEach {
   isReproducibleFileOrder = true
 }
 
+println("Build directory: ${file(layout.buildDirectory)}")
+
 tasks.jacocoTestReport {
   dependsOn(tasks.test) // tests are required to run before generating the report
   reports {
     xml.required.set(false)
     csv.required.set(false)
-    html.outputLocation.set(file("${layout.buildDirectory}/jacocoHtml"))
+    html.outputLocation.set(file("${file(layout.buildDirectory)}/jacocoHtml"))
   }
 }
 

--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -76,6 +76,10 @@ public class ContextMenuMouseListener extends MouseAdapter {
 
         //Add protection for cntl+v
 
+        generate_popup();
+    }
+
+    private void generate_popup() {
         undoAction = new AbstractAction("Undo") {
 
             @Override
@@ -157,6 +161,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
         if (e.isPopupTrigger()) {
             if(this.popup == null) {
                 popup = new JPopupMenu();
+                generate_popup();
             }
             popup.show(e.getComponent(), e.getX(), e.getY());
         }

--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -21,13 +21,49 @@ import javax.swing.text.JTextComponent;
 public class ContextMenuMouseListener extends MouseAdapter {
     private JPopupMenu popup = new JPopupMenu();
 
+    public String getDebugSavedString() {
+        return debugSavedString;
+    }
+
+    private String debugSavedString;
+
+    public Action getCutAction() {
+        return cutAction;
+    }
+
     private Action cutAction;
     private Action copyAction;
     private Action pasteAction;
+
+    public Action getCopyAction() {
+        return copyAction;
+    }
+
+    public Action getPasteAction() {
+        return pasteAction;
+    }
+
+    public Action getUndoAction() {
+        return undoAction;
+    }
+
+    public Action getSelectAllAction() {
+        return selectAllAction;
+    }
+
     private Action undoAction;
     private Action selectAllAction;
 
+    public JTextComponent getTextComponent() {
+        return textComponent;
+    }
+
     private JTextComponent textComponent;
+
+    public String getSavedString() {
+        return savedString;
+    }
+
     private String savedString = "";
     private Actions lastActionSelected;
 
@@ -46,7 +82,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             public void actionPerformed(ActionEvent ae) {
                 textComponent.setText("");
                 textComponent.replaceSelection(savedString);
-
+                debugSavedString = textComponent.getText();
                 lastActionSelected = Actions.UNDO;
             }
         };
@@ -60,6 +96,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.CUT;
                 savedString = textComponent.getText();
+                debugSavedString = savedString;
                 textComponent.cut();
             }
         };
@@ -71,6 +108,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.COPY;
+                debugSavedString = textComponent.getText();
                 textComponent.copy();
             }
         };
@@ -83,6 +121,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.PASTE;
                 savedString = textComponent.getText();
+                debugSavedString = savedString;
                 ContextActionProtections.pasteFromClipboard(textComponent);
             }
         };
@@ -95,6 +134,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.SELECT_ALL;
+                debugSavedString = textComponent.getText();
                 textComponent.selectAll();
             }
         };

--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -1,5 +1,7 @@
 package com.rarchives.ripme.ui;
 
+import com.rarchives.ripme.uiUtils.ContextActionProtections;
+
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
@@ -37,14 +39,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
         this.textComponent = ripTextfield;
 
         //Add protection for cntl+v
-        ripTextfield.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyTyped(KeyEvent e) {
-                if (e.getKeyChar() == 22) { // ASCII code for Ctrl+V
-                    pasteFromClipboard();
-                }
-            }
-        });
+
         undoAction = new AbstractAction("Undo") {
 
             @Override
@@ -88,8 +83,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.PASTE;
                 savedString = textComponent.getText();
-//                textComponent.paste();
-                pasteFromClipboard();
+                ContextActionProtections.pasteFromClipboard(textComponent);
             }
         };
 
@@ -108,23 +102,7 @@ public class ContextMenuMouseListener extends MouseAdapter {
         popup.add(selectAllAction);
     }
 
-    private void pasteFromClipboard() {
-        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        Transferable transferable = clipboard.getContents(this);
 
-        try {
-            String clipboardContent = (String) transferable.getTransferData(DataFlavor.stringFlavor);
-
-            // Limit the pasted content to 96 characters
-            if (clipboardContent.length() > 96) {
-                clipboardContent = clipboardContent.substring(0, 96);
-            }
-            // Set the text in the JTextField
-            textComponent.setText(clipboardContent);
-        } catch (UnsupportedFlavorException | IOException unable_to_modify_text_on_paste) {
-            unable_to_modify_text_on_paste.printStackTrace();
-        }
-    }
     @Override
     public void mousePressed(MouseEvent e) {
         showPopup(e);

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -51,10 +51,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     private static JFrame mainFrame;
 
-    public static JTextField getRipTextfield() {
-        return ripTextfield;
-    }
-
     private static JTextField ripTextfield;
     private static JButton ripButton, stopButton;
 

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1,6 +1,7 @@
 package com.rarchives.ripme.ui;
 
 import com.rarchives.ripme.ripper.AbstractRipper;
+import com.rarchives.ripme.uiUtils.ContextActionProtections;
 import com.rarchives.ripme.utils.RipUtils;
 import com.rarchives.ripme.utils.Utils;
 import org.apache.logging.log4j.Level;
@@ -21,16 +22,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.text.*;
 import java.awt.*;
 import java.awt.TrayIcon.MessageType;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -283,7 +275,45 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
         ripTextfield = new JTextField("", 20);
         ripTextfield.addMouseListener(new ContextMenuMouseListener(ripTextfield));
-//        ((AbstractDocument) ripTextfield.getDocument()).setDocumentFilter(new LengthLimitDocumentFilter(256));
+
+        //Add keyboard protection of cntl + v for pasting.
+        ripTextfield.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                if (e.getKeyChar() == 22) { // ASCII code for Ctrl+V
+                    ContextActionProtections.pasteFromClipboard(ripTextfield);
+                }
+            }
+        });
+
+        /*
+        Alternatively, just set this, and use
+        ((AbstractDocument) ripTextfield.getDocument()).setDocumentFilter(new LengthLimitDocumentFilter(256));
+            private static class LengthLimitDocumentFilter extends DocumentFilter {
+                private final int maxLength;
+
+                public LengthLimitDocumentFilter(int maxLength) {
+                    this.maxLength = maxLength;
+                }
+
+                @Override
+                public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) throws BadLocationException {
+        //            if ((fb.getDocument().getLength() + string.length()) <= maxLength) {
+                        super.insertString(fb, offset, string.substring(0, maxLength), attr);
+        //            }
+                }
+
+                @Override
+                public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
+                    int currentLength = fb.getDocument().getLength();
+                    int newLength = currentLength - length + text.length();
+
+        //            if (newLength <= maxLength) {
+                    super.replace(fb, offset, length, text.substring(0, maxLength), attrs);
+        //            }
+                }
+            }
+         */
 
         ImageIcon ripIcon = new ImageIcon(mainIcon);
         ripButton = new JButton("<html><font size=\"5\"><b>Rip</b></font></html>", ripIcon);

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -18,12 +18,13 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.SimpleAttributeSet;
-import javax.swing.text.StyleConstants;
-import javax.swing.text.StyledDocument;
+import javax.swing.text.*;
 import java.awt.*;
 import java.awt.TrayIcon.MessageType;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -281,7 +282,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         }
 
         ripTextfield = new JTextField("", 20);
-        ripTextfield.addMouseListener(new ContextMenuMouseListener());
+        ripTextfield.addMouseListener(new ContextMenuMouseListener(ripTextfield));
+//        ((AbstractDocument) ripTextfield.getDocument()).setDocumentFilter(new LengthLimitDocumentFilter(256));
+
         ImageIcon ripIcon = new ImageIcon(mainIcon);
         ripButton = new JButton("<html><font size=\"5\"><b>Rip</b></font></html>", ripIcon);
         stopButton = new JButton("<html><font size=\"5\"><b>Stop</b></font></html>");

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -50,6 +50,11 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private boolean isRipping = false; // Flag to indicate if we're ripping something
 
     private static JFrame mainFrame;
+
+    public static JTextField getRipTextfield() {
+        return ripTextfield;
+    }
+
     private static JTextField ripTextfield;
     private static JButton ripButton, stopButton;
 

--- a/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
+++ b/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
@@ -1,0 +1,30 @@
+package com.rarchives.ripme.uiUtils;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+
+public class ContextActionProtections {
+    public static void pasteFromClipboard(JTextComponent textComponent) {
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        Transferable transferable = clipboard.getContents(new Object());
+
+        try {
+            String clipboardContent = (String) transferable.getTransferData(DataFlavor.stringFlavor);
+
+            // Limit the pasted content to 96 characters
+            if (clipboardContent.length() > 96) {
+                clipboardContent = clipboardContent.substring(0, 96);
+            }
+            // Set the text in the JTextField
+            textComponent.setText(clipboardContent);
+        } catch (UnsupportedFlavorException | IOException unable_to_modify_text_on_paste) {
+            unable_to_modify_text_on_paste.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
+++ b/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
@@ -1,0 +1,44 @@
+package com.rarchives.ripme.ui;
+
+import com.rarchives.ripme.App;
+import com.rarchives.ripme.uiUtils.ContextActionProtections;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UIContextMenuTests {
+    @Test
+    void testCtrlVPasteFromClipboard() throws IOException {
+        // Create a JTextField for testing
+        JTextField textField = new JTextField();
+
+        // Create a test instance of JTextComponent
+        JTextComponentTestImpl textComponent = new JTextComponentTestImpl(textField);
+        // Set some content in the clipboard
+        String clipboardContent = "Test clipboard content";
+        textField.setText(clipboardContent);
+
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(new StringSelection(clipboardContent), null);
+
+        // Simulate the paste event
+        ContextActionProtections.pasteFromClipboard(textComponent);
+
+        // Verify the text in the JTextField after the paste event
+        assertEquals(clipboardContent, textField.getText());
+    }
+    // A test implementation of JTextComponent for testing purposes
+    private static class JTextComponentTestImpl extends JTextPane {
+        JTextComponentTestImpl(JTextComponent delegate) {
+            setText(delegate.getText());
+        }
+    }
+}

--- a/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
+++ b/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
@@ -5,12 +5,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
-import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -161,10 +159,9 @@ public class UIContextMenuTests {
         contextMenuMouseListener.getCopyAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
 
         // Verify that the copy operation worked
-        String expectedText = initialText; // Assuming the entire text is copied
         String actualText = contextMenuMouseListener.getDebugSavedString();
 
-        if (expectedText.equals(actualText)) {
+        if (initialText.equals(actualText)) {
             System.out.println("Copy operation successful. Text content matches.");
         } else {
             fail("Copy operation failed. Text content does not match.");
@@ -179,19 +176,12 @@ public class UIContextMenuTests {
         contextMenuMouseListener.getCutAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
 
         // Verify that the cut operation worked
-        String expectedText = initialText; // Assuming the entire text is cut
         String actualText = contextMenuMouseListener.getDebugSavedString();
 
-        if (expectedText.equals(actualText)) {
+        if (initialText.equals(actualText)) {
             System.out.println("Cut operation successful. Text content matches.");
         } else {
             fail("Cut operation failed. Text content does not match.");
-        }
-    }
-    // A test implementation of JTextComponent for testing purposes
-    private static class JTextComponentTestImpl extends JTextPane {
-        JTextComponentTestImpl(JTextComponent delegate) {
-            setText(delegate.getText());
         }
     }
 }

--- a/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
+++ b/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
@@ -2,38 +2,198 @@ package com.rarchives.ripme.ui;
 
 import com.rarchives.ripme.App;
 import com.rarchives.ripme.uiUtils.ContextActionProtections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
+import javax.swing.text.EditorKit;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UIContextMenuTests {
+
+    private JFrame frame;
+    private JTextField textField;
+    private ContextMenuMouseListener contextMenuMouseListener;
+
+    @BeforeEach
+    void setUp() throws IOException, InterruptedException, InvocationTargetException {
+        AtomicBoolean notDone = new AtomicBoolean(true);
+
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("ContextMenuMouseListener Example");
+            textField = new JTextField("Hello, world!");
+
+            // Create an instance of ContextMenuMouseListener
+            contextMenuMouseListener = new ContextMenuMouseListener(textField);
+
+            // Add ContextMenuMouseListener to JTextField
+            textField.addMouseListener(contextMenuMouseListener);
+
+            frame.getContentPane().add(textField, BorderLayout.CENTER);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.setSize(300, 200);
+            frame.setVisible(true);
+
+            notDone.set(false);
+        });
+
+        // Wait for the GUI to be fully initialized
+        while (notDone.get()) {
+            Thread.yield();
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        frame.dispose();
+    }
+
     @Test
-    void testCtrlVPasteFromClipboard() throws IOException {
-        // Create a JTextField for testing
-        JTextField textField = new JTextField();
+    void testCut() {
+        // Simulate a cut event
+        simulateCutEvent();
+        // Add assertions if needed
+    }
 
-        // Create a test instance of JTextComponent
-        JTextComponentTestImpl textComponent = new JTextComponentTestImpl(textField);
-        // Set some content in the clipboard
-        String clipboardContent = "Test clipboard content";
-        textField.setText(clipboardContent);
+    @Test
+    void testCopy() {
+        // Simulate a copy event
+        simulateCopyEvent();
+        // Add assertions if needed
+    }
 
+    @Test
+    void testPaste() {
+        // Simulate a paste event
+        simulatePasteEvent();
+        // Add assertions if needed
+    }
+
+    @Test
+    void testSelectAll() {
+        // Simulate a select all event
+        simulateSelectAllEvent();
+        // Add assertions if needed
+    }
+
+    @Test
+    void testUndo() {
+        // Simulate an undo event
+        simulateUndoEvent();
+        // Add assertions if needed
+    }
+
+    private void simulatePasteEvent() {
+        // Save the initial text content
+        String initialText = contextMenuMouseListener.getTextComponent().getText();
+
+        // Assume there is some text to paste
+        String textToPaste = "Text to paste";
+
+        // Set the text to the clipboard
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        clipboard.setContents(new StringSelection(clipboardContent), null);
+        StringSelection stringSelection = new StringSelection(textToPaste);
+        clipboard.setContents(stringSelection, stringSelection);
 
-        // Simulate the paste event
-        ContextActionProtections.pasteFromClipboard(textComponent);
+        // Simulate a paste event
+        contextMenuMouseListener.getTextComponent().paste();
 
-        // Verify the text in the JTextField after the paste event
-        assertEquals(clipboardContent, textField.getText());
+        // Verify that the paste operation worked
+        String actualText = contextMenuMouseListener.getTextComponent().getText();
+
+        // Check if the text was appended after the initial text
+        if (actualText.equals(initialText + textToPaste)) {
+            System.out.println("Paste operation successful. Text content matches.");
+        } else {
+            fail("Paste operation failed. Text content does not match.");
+        }
+    }
+
+
+
+
+    private void simulateSelectAllEvent() {
+        // Simulate a select all event by invoking the selectAllAction
+        contextMenuMouseListener.getSelectAllAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
+
+        // Verify that all text is selected
+        int expectedSelectionStart = 0;
+        int expectedSelectionEnd = contextMenuMouseListener.getTextComponent().getText().length();
+        int actualSelectionStart = contextMenuMouseListener.getTextComponent().getSelectionStart();
+        int actualSelectionEnd = contextMenuMouseListener.getTextComponent().getSelectionEnd();
+
+        if (expectedSelectionStart == actualSelectionStart && expectedSelectionEnd == actualSelectionEnd) {
+            System.out.println("Select All operation successful. Text is selected.");
+        } else {
+            fail("Select All operation failed. Text is not selected as expected.");
+        }
+    }
+
+    private void simulateUndoEvent() {
+
+        // Simulate an undo event by invoking the undoAction
+        contextMenuMouseListener.getUndoAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
+
+        // Verify that the undo operation worked
+        String expectedText = contextMenuMouseListener.getSavedString(); // Assuming the undo reverts to the saved state
+        String actualText = contextMenuMouseListener.getTextComponent().getText();
+
+        if (expectedText.equals(actualText)) {
+            System.out.println("Undo operation successful. Text content matches.");
+        } else {
+            fail("Undo operation failed. Text content does not match.");
+        }
+    }
+
+
+    private void simulateCopyEvent() {
+        // Save the initial text content
+        String initialText = contextMenuMouseListener.getTextComponent().getText();
+
+        // Simulate a copy event by invoking the copyAction
+        contextMenuMouseListener.getCopyAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
+
+        // Verify that the copy operation worked
+        String expectedText = initialText; // Assuming the entire text is copied
+        String actualText = contextMenuMouseListener.getDebugSavedString();
+
+        if (expectedText.equals(actualText)) {
+            System.out.println("Copy operation successful. Text content matches.");
+        } else {
+            fail("Copy operation failed. Text content does not match.");
+        }
+    }
+
+    private  void simulateCutEvent() {
+        // Save the initial text content
+        String initialText = contextMenuMouseListener.getTextComponent().getText();
+
+        // Simulate a cut event by invoking the cutAction
+        contextMenuMouseListener.getCutAction().actionPerformed(new ActionEvent(contextMenuMouseListener.getTextComponent(), ActionEvent.ACTION_PERFORMED, ""));
+
+        // Verify that the cut operation worked
+        String expectedText = initialText; // Assuming the entire text is cut
+        String actualText = contextMenuMouseListener.getDebugSavedString();
+
+        if (expectedText.equals(actualText)) {
+            System.out.println("Cut operation successful. Text content matches.");
+        } else {
+            fail("Cut operation failed. Text content does not match.");
+        }
     }
     // A test implementation of JTextComponent for testing purposes
     private static class JTextComponentTestImpl extends JTextPane {

--- a/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
+++ b/src/test/java/com/rarchives/ripme/ui/UIContextMenuTests.java
@@ -1,26 +1,19 @@
 package com.rarchives.ripme.ui;
 
-import com.rarchives.ripme.App;
-import com.rarchives.ripme.uiUtils.ContextActionProtections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
-import javax.swing.text.EditorKit;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class UIContextMenuTests {
@@ -30,7 +23,7 @@ public class UIContextMenuTests {
     private ContextMenuMouseListener contextMenuMouseListener;
 
     @BeforeEach
-    void setUp() throws IOException, InterruptedException, InvocationTargetException {
+    void setUp() throws InterruptedException, InvocationTargetException {
         AtomicBoolean notDone = new AtomicBoolean(true);
 
         SwingUtilities.invokeAndWait(() -> {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixes issue with copy/pasting. Fixes right click context menu. Fixes pasting >96 characters and the UI growing to that size.

FYI: I've never touched any of these libraries before so this is mostly googling/etc for the last few hours. I probably need to fix the junits (they run but I am not 100% convinced they do what I actually want). 

My Branch
![My Branch](https://github.com/ripmeapp2/ripme/assets/24619207/29d434f2-57c8-4135-ba76-4bd2012f1670 "Well you can't see but you can't right click")

Main
![Main.](https://github.com/ripmeapp2/ripme/assets/24619207/88689b9e-e236-4de2-945b-6d82c256d344 "Main")



# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors). -> gradle test, maven isn't used (Unless I am blind)
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change. (They're maybe ok..)
