### PR TITLE
Danbooru fix downloads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation("org.apache.httpcomponents:httpmime:4.5.14")
   implementation("org.apache.logging.log4j:log4j-api:2.20.0")
   implementation("org.apache.logging.log4j:log4j-core:2.20.0")
+  implementation("com.squareup.okhttp3:okhttp:4.12.0")
   implementation("org.graalvm.js:js:22.3.2")
   testImplementation(enforcedPlatform("org.junit:junit-bom:5.10.0"))
   testImplementation("org.junit.jupiter:junit-jupiter")
@@ -68,7 +69,7 @@ tasks.withType<Jar> {
     attributes["Implementation-Version"] =  archiveVersion
     attributes["Multi-Release"] = "true"
   }
- 
+
   // To add all of the dependencies otherwise a "NoClassDefFoundError" error
   from(sourceSets.main.get().output)
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DanbooruRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DanbooruRipper.java
@@ -172,7 +172,7 @@ public class DanbooruRipper extends AbstractJSONRipper {
     }
 
     private String getTag(URL url) throws MalformedURLException {
-        gidPattern = Pattern.compile("https?://danbooru.donmai.us/(posts)?.*([?&]tags=([a-zA-Z0-9$_.+!*'(),%-]+))(&|(#.*)?$)");
+        gidPattern = Pattern.compile("https?://danbooru.donmai.us/(posts)?.*([?&]tags=([^&]*)(?:&z=([0-9]+))?$)");
         Matcher m = gidPattern.matcher(url.toExternalForm());
 
         if (m.matches()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DanbooruRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DanbooruRipper.java
@@ -6,6 +6,7 @@ import com.rarchives.ripme.utils.Utils;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Connection;
@@ -61,57 +62,18 @@ public class DanbooruRipper extends AbstractJSONRipper {
     private final String userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0";
     @Override
     protected JSONObject getFirstPage() throws MalformedURLException {
-
-        OkHttpClient client = new OkHttpClient.Builder()
-                .readTimeout(60, TimeUnit.SECONDS)
-                .writeTimeout(60, TimeUnit.SECONDS)
-                .build();
-
-        Request request = new Request.Builder()
-                .url(getPage(1)) // make sure to implement getPage method
-                .header("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1")
-                .header("Accept", "application/json,text/javascript,*/*;q=0.01")
-                .header("Accept-Language", "en-US,en;q=0.9")
-                .header("Sec-Fetch-Dest", "empty")
-                .header("Sec-Fetch-Mode", "cors")
-                .header("Sec-Fetch-Site", "same-origin")
-                .header("Referer", "https://danbooru.donmai.us/")
-                .header("X-Requested-With", "XMLHttpRequest")
-                .header("Connection", "keep-alive")
-                .build();
-
-        Response response = null;
-        try {
-            response = client.newCall(request).execute();
-            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
-
-            // Response body is automatically decompressed
-            String responseData = response.body().string();
-            // Parsing the responseData to a JSONArray
-            JSONArray jsonArray = new JSONArray(responseData);
-            System.out.println(jsonArray.toString());
-
-            String newCompatibleJSON = "{ \"resources\":" + jsonArray.toString() + " }";
-            return new JSONObject(newCompatibleJSON);
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            if(response !=null) {
-                response.body().close();
-            }
-        }
-        return null; // Return null or a default value in case of error
+        return getCurrentPage();
     }
 
     @Override
     protected JSONObject getNextPage(JSONObject doc) throws IOException {
-        currentPageNum++;
+        return getCurrentPage();
+    }
 
-
-
+    @Nullable
+    private JSONObject getCurrentPage() throws MalformedURLException {
         Request request = new Request.Builder()
-                .url(getPage(currentPageNum)) // make sure to implement getPage method
+                .url(getPage(currentPageNum))
                 .header("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1")
                 .header("Accept", "application/json,text/javascript,*/*;q=0.01")
                 .header("Accept-Language", "en-US,en;q=0.9")
@@ -123,6 +85,7 @@ public class DanbooruRipper extends AbstractJSONRipper {
                 .header("Connection", "keep-alive")
                 .build();
         Response response = null;
+        currentPageNum++;
         try {
             response = client.newCall(request).execute();
             if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [X] a refactoring
* [X] a style change/fix
* [ ] a new feature

https://regex101.com/r/sZD31Y/1

I changed the DanbooruRipper class to use OkHttpClient which should make things run faster and be a little easier (at least for Danbooru)
I tried getting a connection with Jsoup.connect using a bunch of headers. It seemed to work, but the data that came back made no sense. I could not figure out how to get it to not be gibberish, I know it was encoded via br (Brotli); therefore, I figured I might as well default to a library that can handle it. 
So, all in all, just some tweaks to make DanbooruRipper more reliable - maybe


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [-] I've added a unit test to cover my change. -> There already was one.
