### PR TITLE
HistoryMenuMouseListener right click menu fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
@@ -62,7 +62,16 @@ class HistoryMenuMouseListener extends MouseAdapter {
     }
 
     @Override
-    public void mouseClicked(MouseEvent e) {
+    public void mousePressed(MouseEvent e) {
+        checkPopupTrigger(e);
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        checkPopupTrigger(e);
+    }
+
+    private void checkPopupTrigger(MouseEvent e) {
         if (e.getModifiersEx() == InputEvent.BUTTON3_DOWN_MASK) {
             if (!(e.getSource() instanceof JTable)) {
                 return;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #173 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
History menu right click options menu did not work

# Testing
Tried it manually, works