### PR TITLE
Ignore SSL verification option added

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -36,7 +36,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
 
     protected AbstractHTMLRipper(URL url) throws IOException {
         super(url);
-        if(Utils.getConfigBoolean("ignore.ssl_verification",false)){
+        if(Utils.getConfigBoolean("ssl.verify.off",false)){
             Http.ignoreSSLVerification();
         }else {
             Http.undoSSLVerificationIgnore();

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -36,6 +36,11 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
 
     protected AbstractHTMLRipper(URL url) throws IOException {
         super(url);
+        if(Utils.getConfigBoolean("ignore.ssl_verification",false)){
+            Http.ignoreSSLVerification();
+        }else {
+            Http.undoSSLVerificationIgnore();
+        }
     }
 
     protected abstract String getDomain();

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -37,9 +37,9 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
     protected AbstractHTMLRipper(URL url) throws IOException {
         super(url);
         if(Utils.getConfigBoolean("ssl.verify.off",false)){
-            Http.ignoreSSLVerification();
+            Http.SSLVerifyOff();
         }else {
-            Http.undoSSLVerificationIgnore();
+            Http.undoSSLVerifyOff();
         }
     }
 

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -95,6 +95,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private static JCheckBox configAutoupdateCheckbox;
     private static JComboBox<String> configLogLevelCombobox;
     private static JCheckBox configURLHistoryCheckbox;
+    private static JCheckBox configIgnoreSSLCertificate;
     private static JCheckBox configPlaySound;
     private static JCheckBox configSaveOrderCheckbox;
     private static JCheckBox configShowPopup;
@@ -212,6 +213,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         Utils.setConfigBoolean("descriptions.save", configSaveDescriptions.isSelected());
         Utils.setConfigBoolean("prefer.mp4", configPreferMp4.isSelected());
         Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
+        Utils.setConfigBoolean("ignore.ssl_verification", configIgnoreSSLCertificate.isSelected());
         Utils.setConfigString("lang", configSelectLangComboBox.getSelectedItem().toString());
         saveWindowPosition(mainFrame);
         saveHistory();
@@ -565,6 +567,8 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 true);
         configURLHistoryCheckbox = addNewCheckbox(Utils.getLocalizedString("remember.url.history"),
                 "remember.url_history", true);
+        configIgnoreSSLCertificate = addNewCheckbox(Utils.getLocalizedString("ignore.ssl_verification"),
+                "ignore.ssl_verification", true);
         configUrlFileChooserButton = new JButton(Utils.getLocalizedString("download.url.list"));
 
         configLogLevelCombobox = new JComboBox<>(
@@ -599,6 +603,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         addItemToConfigGridBagConstraints(gbc, idx++, configClipboardAutorip, configSaveAlbumTitles);
         addItemToConfigGridBagConstraints(gbc, idx++, configSaveDescriptions, configPreferMp4);
         addItemToConfigGridBagConstraints(gbc, idx++, configWindowPosition, configURLHistoryCheckbox);
+        addItemToConfigGridBagConstraints(gbc, idx++, configIgnoreSSLCertificate, configIgnoreSSLCertificate);
         addItemToConfigGridBagConstraints(gbc, idx++, configSelectLangComboBox, configUrlFileChooserButton);
         addItemToConfigGridBagConstraints(gbc, idx++, configSaveDirLabel, configSaveDirButton);
 
@@ -738,6 +743,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configPreferMp4.setText(Utils.getLocalizedString("prefer.mp4.over.gif"));
         configWindowPosition.setText(Utils.getLocalizedString("restore.window.position"));
         configURLHistoryCheckbox.setText(Utils.getLocalizedString("remember.url.history"));
+        configIgnoreSSLCertificate.setText(Utils.getLocalizedString("ignore.ssl_verification"));
         optionLog.setText(Utils.getLocalizedString("Log"));
         optionHistory.setText(Utils.getLocalizedString("History"));
         optionQueue.setText(Utils.getLocalizedString("queue"));
@@ -1012,6 +1018,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         addCheckboxListener(configSaveLogs, "log.save");
         addCheckboxListener(configSaveURLsOnly, "urls_only.save");
         addCheckboxListener(configURLHistoryCheckbox, "remember.url_history");
+        addCheckboxListener(configIgnoreSSLCertificate, "ignore.ssl_verification");
         addCheckboxListener(configSaveAlbumTitles, "album_titles.save");
         addCheckboxListener(configSaveDescriptions, "descriptions.save");
         addCheckboxListener(configPreferMp4, "prefer.mp4");
@@ -1528,8 +1535,8 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             }
             /*
              * content key %path% the path to the album folder %url% is the album url
-             * 
-             * 
+             *
+             *
              */
             if (Utils.getConfigBoolean("enable.finish.command", false)) {
                 try {

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -95,7 +95,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private static JCheckBox configAutoupdateCheckbox;
     private static JComboBox<String> configLogLevelCombobox;
     private static JCheckBox configURLHistoryCheckbox;
-    private static JCheckBox configIgnoreSSLCertificate;
+    private static JCheckBox configSSLVerifyOff;
     private static JCheckBox configPlaySound;
     private static JCheckBox configSaveOrderCheckbox;
     private static JCheckBox configShowPopup;
@@ -213,7 +213,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         Utils.setConfigBoolean("descriptions.save", configSaveDescriptions.isSelected());
         Utils.setConfigBoolean("prefer.mp4", configPreferMp4.isSelected());
         Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
-        Utils.setConfigBoolean("ssl.verify.off", configIgnoreSSLCertificate.isSelected());
+        Utils.setConfigBoolean("ssl.verify.off", configSSLVerifyOff.isSelected());
         Utils.setConfigString("lang", configSelectLangComboBox.getSelectedItem().toString());
         saveWindowPosition(mainFrame);
         saveHistory();
@@ -567,7 +567,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 true);
         configURLHistoryCheckbox = addNewCheckbox(Utils.getLocalizedString("remember.url.history"),
                 "remember.url_history", true);
-        configIgnoreSSLCertificate = addNewCheckbox(Utils.getLocalizedString("ssl.verify.off"),
+        configSSLVerifyOff = addNewCheckbox(Utils.getLocalizedString("ssl.verify.off"),
                 "ssl.verify.off", false);
         configUrlFileChooserButton = new JButton(Utils.getLocalizedString("download.url.list"));
 
@@ -603,7 +603,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         addItemToConfigGridBagConstraints(gbc, idx++, configClipboardAutorip, configSaveAlbumTitles);
         addItemToConfigGridBagConstraints(gbc, idx++, configSaveDescriptions, configPreferMp4);
         addItemToConfigGridBagConstraints(gbc, idx++, configWindowPosition, configURLHistoryCheckbox);
-        addItemToConfigGridBagConstraints(gbc, idx++, configIgnoreSSLCertificate, configIgnoreSSLCertificate);
+        addItemToConfigGridBagConstraints(gbc, idx++, configSSLVerifyOff, configSSLVerifyOff);
         addItemToConfigGridBagConstraints(gbc, idx++, configSelectLangComboBox, configUrlFileChooserButton);
         addItemToConfigGridBagConstraints(gbc, idx++, configSaveDirLabel, configSaveDirButton);
 
@@ -743,7 +743,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configPreferMp4.setText(Utils.getLocalizedString("prefer.mp4.over.gif"));
         configWindowPosition.setText(Utils.getLocalizedString("restore.window.position"));
         configURLHistoryCheckbox.setText(Utils.getLocalizedString("remember.url.history"));
-        configIgnoreSSLCertificate.setText(Utils.getLocalizedString("ssl.verify.off"));
+        configSSLVerifyOff.setText(Utils.getLocalizedString("ssl.verify.off"));
         optionLog.setText(Utils.getLocalizedString("Log"));
         optionHistory.setText(Utils.getLocalizedString("History"));
         optionQueue.setText(Utils.getLocalizedString("queue"));
@@ -1018,7 +1018,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         addCheckboxListener(configSaveLogs, "log.save");
         addCheckboxListener(configSaveURLsOnly, "urls_only.save");
         addCheckboxListener(configURLHistoryCheckbox, "remember.url_history");
-        addCheckboxListener(configIgnoreSSLCertificate, "ssl.verify.off");
+        addCheckboxListener(configSSLVerifyOff, "ssl.verify.off");
         addCheckboxListener(configSaveAlbumTitles, "album_titles.save");
         addCheckboxListener(configSaveDescriptions, "descriptions.save");
         addCheckboxListener(configPreferMp4, "prefer.mp4");

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -568,7 +568,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configURLHistoryCheckbox = addNewCheckbox(Utils.getLocalizedString("remember.url.history"),
                 "remember.url_history", true);
         configIgnoreSSLCertificate = addNewCheckbox(Utils.getLocalizedString("ignore.ssl_verification"),
-                "ignore.ssl_verification", true);
+                "ignore.ssl_verification", false);
         configUrlFileChooserButton = new JButton(Utils.getLocalizedString("download.url.list"));
 
         configLogLevelCombobox = new JComboBox<>(

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -213,7 +213,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         Utils.setConfigBoolean("descriptions.save", configSaveDescriptions.isSelected());
         Utils.setConfigBoolean("prefer.mp4", configPreferMp4.isSelected());
         Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
-        Utils.setConfigBoolean("ignore.ssl_verification", configIgnoreSSLCertificate.isSelected());
+        Utils.setConfigBoolean("ssl.verify.off", configIgnoreSSLCertificate.isSelected());
         Utils.setConfigString("lang", configSelectLangComboBox.getSelectedItem().toString());
         saveWindowPosition(mainFrame);
         saveHistory();
@@ -567,8 +567,8 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 true);
         configURLHistoryCheckbox = addNewCheckbox(Utils.getLocalizedString("remember.url.history"),
                 "remember.url_history", true);
-        configIgnoreSSLCertificate = addNewCheckbox(Utils.getLocalizedString("ignore.ssl_verification"),
-                "ignore.ssl_verification", false);
+        configIgnoreSSLCertificate = addNewCheckbox(Utils.getLocalizedString("ssl.verify.off"),
+                "ssl.verify.off", false);
         configUrlFileChooserButton = new JButton(Utils.getLocalizedString("download.url.list"));
 
         configLogLevelCombobox = new JComboBox<>(
@@ -743,7 +743,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configPreferMp4.setText(Utils.getLocalizedString("prefer.mp4.over.gif"));
         configWindowPosition.setText(Utils.getLocalizedString("restore.window.position"));
         configURLHistoryCheckbox.setText(Utils.getLocalizedString("remember.url.history"));
-        configIgnoreSSLCertificate.setText(Utils.getLocalizedString("ignore.ssl_verification"));
+        configIgnoreSSLCertificate.setText(Utils.getLocalizedString("ssl.verify.off"));
         optionLog.setText(Utils.getLocalizedString("Log"));
         optionHistory.setText(Utils.getLocalizedString("History"));
         optionQueue.setText(Utils.getLocalizedString("queue"));
@@ -1018,7 +1018,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         addCheckboxListener(configSaveLogs, "log.save");
         addCheckboxListener(configSaveURLsOnly, "urls_only.save");
         addCheckboxListener(configURLHistoryCheckbox, "remember.url_history");
-        addCheckboxListener(configIgnoreSSLCertificate, "ignore.ssl_verification");
+        addCheckboxListener(configIgnoreSSLCertificate, "ssl.verify.off");
         addCheckboxListener(configSaveAlbumTitles, "album_titles.save");
         addCheckboxListener(configSaveDescriptions, "descriptions.save");
         addCheckboxListener(configPreferMp4, "prefer.mp4");

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -234,7 +234,7 @@ public class Http {
         throw new IOException("Failed to load " + url + " after " + this.retries + " attempts", lastException);
     }
 
-    public static void ignoreSSLVerification() {
+    public static void SSLVerifyOff() {
         try {
             TrustManager[] trustAllCerts = new TrustManager[]{
                     new X509TrustManager() {
@@ -260,7 +260,7 @@ public class Http {
         }
     }
 
-    public static void undoSSLVerificationIgnore() {
+    public static void undoSSLVerifyOff() {
         try {
             // Reset to the default SSL socket factory and hostname verifier
             SSLContext sslContext = SSLContext.getInstance("SSL");

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -43,9 +43,6 @@ public class Http {
     public Http(String url) {
         this.url = url;
         defaultSettings();
-        if(Utils.getConfigBoolean("ignore.ssl_verification",false)){
-            ignoreSSLVerification();
-        }
     }
 
     private Http(URL url) {
@@ -237,7 +234,7 @@ public class Http {
         throw new IOException("Failed to load " + url + " after " + this.retries + " attempts", lastException);
     }
 
-    private void ignoreSSLVerification() {
+    public static void ignoreSSLVerification() {
         try {
             TrustManager[] trustAllCerts = new TrustManager[]{
                     new X509TrustManager() {
@@ -257,9 +254,19 @@ public class Http {
             HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
             HostnameVerifier allHostsValid = (hostname, session) -> true;
             HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
-        } catch (Exception e) {
-            logger.error("ignoreSSLVerification() failed.");
-            logger.error(e.getMessage());
+            System.out.println("ignoreSSLVerification");
+        } catch (Exception ignored) {
+        }
+    }
+
+    public static void undoSSLVerificationIgnore() {
+        try {
+            // Reset to the default SSL socket factory and hostname verifier
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, null, new SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+            HttpsURLConnection.setDefaultHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier());
+        } catch (Exception ignored) {
         }
     }
 }

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -254,8 +254,9 @@ public class Http {
             HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
             HostnameVerifier allHostsValid = (hostname, session) -> true;
             HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
-            System.out.println("ignoreSSLVerification");
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            logger.error("ignoreSSLVerification() failed.");
+            logger.error(e.getMessage());
         }
     }
 
@@ -266,7 +267,9 @@ public class Http {
             sslContext.init(null, null, new SecureRandom());
             HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
             HttpsURLConnection.setDefaultHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier());
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            logger.error("undoSSLVerificationIgnore() failed.");
+            logger.error(e.getMessage());
         }
     }
 }

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -26,7 +26,7 @@ save.descriptions = Save descriptions
 prefer.mp4.over.gif = Prefer MP4 over GIF
 restore.window.position = Restore window position
 remember.url.history = Remember URL history
-ignore.ssl_verification = SSL verify off
+ssl.verify.off = SSL verify off
 loading.history.from = Loading history from
 
 # Queue keys

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -26,7 +26,7 @@ save.descriptions = Save descriptions
 prefer.mp4.over.gif = Prefer MP4 over GIF
 restore.window.position = Restore window position
 remember.url.history = Remember URL history
-ignore.ssl_verification = Ignore SSL verification
+ignore.ssl_verification = SSL verify off
 loading.history.from = Loading history from
 
 # Queue keys

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -26,6 +26,7 @@ save.descriptions = Save descriptions
 prefer.mp4.over.gif = Prefer MP4 over GIF
 restore.window.position = Restore window position
 remember.url.history = Remember URL history
+ignore.ssl_verification = Ignore SSL verification
 loading.history.from = Loading history from
 
 # Queue keys


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #171 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature (Option to ignore SSL verification, requested by 171)

# Description
Added the option to ignore SSL verification as this can cause issues on some websites with bad configurations.

# Testing
Tested with the link from 171, works as expected.