### PR TITLE
Imagefap: add retry logic for getFullSizedImage()

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
@@ -144,8 +144,17 @@ public class ImagefapRipper extends AbstractHTMLRipper {
             }
             String image = getFullSizedImage("https://www.imagefap.com" + thumb.parent().attr("href"));
 
-            if(image == null)
-                throw new RuntimeException("Unable to extract image URL from single image page! Unable to continue");
+            if (image == null) {
+                for (int i = 0; i < HTTP_RETRY_LIMIT; i++) {
+                    image = getFullSizedImage("https://www.imagefap.com" + thumb.parent().attr("href"));
+                    if (image != null) {
+                        break;
+                    }
+                    sleep(PAGE_SLEEP_TIME);
+                }
+                if (image == null)
+                    throw new RuntimeException("Unable to extract image URL from single image page! Unable to continue");
+            }
 
             LOGGER.debug("Adding imageURL: '" + image + "'");
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #179)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Imagefap: add retry logic for getFullSizedImage() as sometimes images fail to be downloaded.

# Testing
**No testing done**, I could not reproduce the issue to test the fix.

Should not introduce regression as if we get in the 
```if (image == null)``` block the execution stops/errors with current implementation.