### PR TITLE
Imagebam ripper fixed

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
@@ -10,11 +10,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -128,7 +131,12 @@ public class ImagebamRipper extends AbstractHTMLRipper {
          */
         private void fetchImage() {
             try {
-                Document doc = Http.url(url).get();
+                Map<String, String> cookies = new HashMap<>();
+                cookies.put("nsfw_inter", "1");
+                Document doc = Jsoup.connect(url.toString())
+                        .cookies(cookies)
+                        .get();
+
                 // Find image
                 Elements metaTags = doc.getElementsByTag("meta");
                 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #185 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Imagebam ripper fixed, image was not loading due to "continue to image" page, not sure what it is for but clicking it sets a nsfw cookie and it never appears again. Changes set the cookie and all looks good.

# Testing
Manually downloaded a couple of galleries
