### PR TITLE
Fixed Motherless ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -5,8 +5,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -17,7 +15,6 @@ import org.jsoup.nodes.Element;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ripper.DownloadThreadPool;
-import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 import org.jsoup.select.Elements;
@@ -71,8 +68,6 @@ public class MotherlessRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getNextPage(Document doc) throws IOException, URISyntaxException {
-
-        Files.write(Paths.get("doc-next-page.txt"), doc.outerHtml().getBytes());
 
         Elements nextPageLink = doc.head().select("link[rel=next]");
         if (nextPageLink.isEmpty()) {

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -56,7 +56,7 @@ public class Http {
     }
 
     private void defaultSettings() {
-        this.retries = Utils.getConfigInteger("download.retries", 1);
+        this.retries = Utils.getConfigInteger("download.retries", 3);
         this.retrySleep = Utils.getConfigInteger("download.retry.sleep", 5000);
         connection = Jsoup.connect(this.url);
         connection.userAgent(AbstractRipper.USER_AGENT);

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -6,7 +6,7 @@ threads.size = 5
 file.overwrite = false
 
 # Number of retries on failed downloads
-download.retries = 1
+download.retries = 3
 
 # File download timeout (in milliseconds)
 download.timeout = 60000

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
@@ -12,15 +12,15 @@ import org.junit.jupiter.api.Test;
 public class VidbleRipperTest extends RippersTest {
     @Test
     public void testVidbleRip() throws IOException, URISyntaxException {
-        VidbleRipper ripper = new VidbleRipper(new URI("http://www.vidble.com/album/y1oyh3zd").toURL());
+        VidbleRipper ripper = new VidbleRipper(new URI("https://vidble.com/album/cGEFr8zi").toURL());
         testRipper(ripper);
     }
 
     @Test
     public void testGetGID() throws IOException, URISyntaxException {
-        URL url = new URI("http://www.vidble.com/album/y1oyh3zd").toURL();
+        URL url = new URI("https://vidble.com/album/cGEFr8zi").toURL();
         VidbleRipper ripper = new VidbleRipper(url);
-        Assertions.assertEquals("y1oyh3zd", ripper.getGID(url));
+        Assertions.assertEquals("cGEFr8zi", ripper.getGID(url));
     }
 }
 


### PR DESCRIPTION
The Motherless ripper was broken as the rip operation was not waiting on all the threads created to download the files from motherless.

This repo reminded me as to why OO inheritance is just plain bad... too hard to follow what's happening!

Also 
- increased default http retries to 3 (why only 1?)
- fixed deprecation message for Motherless ripper

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
