### PR TITLE
QueueMenuMouseListener right click menu fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
@@ -58,9 +58,18 @@ class QueueMenuMouseListener extends MouseAdapter {
         updateQueue.accept(queueListModel);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public void mouseClicked(MouseEvent e) {
+    public void mousePressed(MouseEvent e) {
+        checkPopupTrigger(e);
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        checkPopupTrigger(e);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkPopupTrigger(MouseEvent e) {
         if (e.getModifiersEx() == InputEvent.BUTTON3_DOWN_MASK) {
             if (!(e.getSource() instanceof JList)) {
                 return;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #196 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description

Queue menu right click options menu did not show up.
We previously had the same issue with the history menu - #174 , I reused the fix from there and it looks good for the queue too.

# Testing
Tried it manually, works