### PR TITLE
Fix RGifs ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
@@ -34,10 +34,10 @@ public class RedgifsRipper extends AbstractJSONRipper {
     private static final String SEARCH_ENDPOINT = "https://api.redgifs.com/v2/search/%s";
     private static final String TAGS_ENDPOINT = "https://api.redgifs.com/v2/gifs/search";
     private static final String TEMPORARY_AUTH_ENDPOINT = "https://api.redgifs.com/v2/auth/temporary";
-    private static final Pattern PROFILE_PATTERN = Pattern.compile("^https?://[wm.]*redgifs\\.com/users/([a-zA-Z0-9_.-]+).*$");
-    private static final Pattern SEARCH_PATTERN = Pattern.compile("^https?:\\/\\/[wm.]*redgifs\\.com\\/search(?:\\/[a-zA-Z]+)?\\?.*?query=([a-zA-Z0-9-_+%]+).*$");
-    private static final Pattern TAGS_PATTERN = Pattern.compile("^https?:\\/\\/[wm.]*redgifs\\.com\\/gifs\\/([a-zA-Z0-9_.,-]+).*$");
-    private static final Pattern SINGLETON_PATTERN = Pattern.compile("^https?://[wm.]*redgifs\\.com/watch/([a-zA-Z0-9_-]+).*$");
+    private static final Pattern PROFILE_PATTERN = Pattern.compile("^https?://[a-zA-Z0-9.]*redgifs\\.com/users/([a-zA-Z0-9_.-]+).*$");
+    private static final Pattern SEARCH_PATTERN = Pattern.compile("^https?:\\/\\/[a-zA-Z0-9.]*redgifs\\.com\\/search(?:\\/[a-zA-Z]+)?\\?.*?query=([a-zA-Z0-9-_+%]+).*$");
+    private static final Pattern TAGS_PATTERN = Pattern.compile("^https?:\\/\\/[a-zA-Z0-9.]*redgifs\\.com\\/gifs\\/([a-zA-Z0-9_.,-]+).*$");
+    private static final Pattern SINGLETON_PATTERN = Pattern.compile("^https?://[a-zA-Z0-9.]*redgifs\\.com/watch/([a-zA-Z0-9_-]+).*$");
     
     String username = "";
     String authToken = "";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
@@ -4,8 +4,6 @@ import com.rarchives.ripme.utils.Http;
 
 import org.json.JSONObject;
 
-import static com.rarchives.ripme.App.logger;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -149,7 +147,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
             sText = URLDecoder.decode(sText, StandardCharsets.UTF_8);
             var list = Arrays.asList(sText.split(","));
             if (list.size() > 1) {
-            logger.warn("Url with multiple tags found. \nThey will be sorted alphabetically for folder name.");
+            LOGGER.warn("Url with multiple tags found. \nThey will be sorted alphabetically for folder name.");
             }
             Collections.sort(list);
             var gid = list.stream().reduce("", (acc, val) -> acc.concat("_" + val));
@@ -242,7 +240,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
                 list.add(hdURL);
             }
         } catch (IOException e) {
-            logger.error(String.format("Error fetching gallery %s for gif %s", galleryID, gifID), e);
+            LOGGER.error(String.format("Error fetching gallery %s for gif %s", galleryID, gifID), e);
         }
         return list;
     }
@@ -305,7 +303,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
                     switch (value) {
                         case "gifs" -> endpointQueryParams.put("type", "g");
                         case "images" -> endpointQueryParams.put("type", "i");
-                        default -> logger.warn(String.format("Unsupported tab for tags url %s", value));
+                        default -> LOGGER.warn(String.format("Unsupported tab for tags url %s", value));
                     }
                     break;
                 case "verified": 
@@ -323,7 +321,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
                 case "viewMode":
                     break;
                 default:
-                    logger.warn(String.format("Unexpected query param %s for search url. Skipping.", name));
+                    LOGGER.warn(String.format("Unexpected query param %s for search url. Skipping.", name));
             }                
         }
 
@@ -337,7 +335,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
             }
             // Check if it is the main tags page with all gifs, images, creator etc
             if (!endpointQueryParams.containsKey("type")) {
-                logger.warn("No tab selected, defaulting to gifs");
+                LOGGER.warn("No tab selected, defaulting to gifs");
                 endpointQueryParams.put("type", "g");
             }
             uri = new URIBuilder(TAGS_ENDPOINT);
@@ -348,8 +346,8 @@ public class RedgifsRipper extends AbstractJSONRipper {
                 switch (subpaths[subpaths.length-1]) {
                     case "gifs" -> tabType = "gifs";
                     case "images" -> tabType = "images";
-                    case "search" -> logger.warn("No tab selected, defaulting to gifs");
-                    default -> logger.warn(String.format("Unsupported search tab %s, defaulting to gifs", subpaths[subpaths.length-1]));
+                    case "search" -> LOGGER.warn("No tab selected, defaulting to gifs");
+                    default -> LOGGER.warn(String.format("Unsupported search tab %s, defaulting to gifs", subpaths[subpaths.length-1]));
                 }
             }
             uri = new URIBuilder(String.format(SEARCH_ENDPOINT, tabType));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RedgifsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RedgifsRipperTest.java
@@ -2,7 +2,6 @@ package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.RedditRipper;
 import com.rarchives.ripme.ripper.rippers.RedgifsRipper;
-import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
@@ -15,9 +14,8 @@ public class RedgifsRipperTest extends RippersTest {
      * Rips correctly formatted URL directly from Redgifs
      */
     @Test
-    @Disabled("test or ripper broken")
     public void testRedgifsGoodURL() throws IOException, URISyntaxException {
-        RedgifsRipper ripper = new RedgifsRipper(new URI("https://www.redgifs.com/watch/talkativewarpeddragon-petite").toURL());
+        RedgifsRipper ripper = new RedgifsRipper(new URI("https://www.redgifs.com/watch/ashamedselfishcoypu").toURL());
         testRipper(ripper);
     }
 
@@ -25,36 +23,38 @@ public class RedgifsRipperTest extends RippersTest {
      * Rips gifdeliverynetwork URL's by redirecting them to proper redgifs url
      */
     @Test
-    @Tag("flaky")
     public void testRedgifsBadRL() throws IOException, URISyntaxException {
-        RedgifsRipper ripper = new RedgifsRipper(new URI("https://www.gifdeliverynetwork.com/foolishelasticchimpanzee").toURL());
+        RedgifsRipper ripper = new RedgifsRipper(new URI("https://www.gifdeliverynetwork.com/consideratetrustworthypigeon").toURL());
         testRipper(ripper);
     }
 
     /**
-     * Rips a Redifs profile
+     * Rips a Redgifs profile
      */
     @Test
-    @Tag("flaky")
     public void testRedgifsProfile() throws IOException, URISyntaxException {
-        RedgifsRipper ripper  = new RedgifsRipper(new URI("https://redgifs.com/users/margo_monty").toURL());
+        RedgifsRipper ripper  = new RedgifsRipper(new URI("https://www.redgifs.com/users/ra-kunv2").toURL());
         testRipper(ripper);
     }
 
     /**
-     * Rips a Redifs category/search
+     * Rips a Redgif search
      * @throws IOException
      */
     @Test
-    @Disabled("test or ripper broken")
     public void testRedgifsSearch() throws IOException, URISyntaxException {
-        RedgifsRipper ripper  = new RedgifsRipper(new URI("https://redgifs.com/gifs/browse/little-caprice").toURL());
-        Document doc = ripper.getFirstPage();
+        RedgifsRipper ripper  = new RedgifsRipper(new URI("https://www.redgifs.com/search?query=take+a+shot+every+time").toURL());
+        testRipper(ripper);
+    }
 
-        doc = ripper.getNextPage(doc);
-        Assertions.assertTrue("https://api.redgifs.com/v1/gfycats/search?search_text=little%20caprice&count=150&start=150".equalsIgnoreCase(doc.location()));
-        doc = ripper.getNextPage(doc);
-        Assertions.assertTrue("https://api.redgifs.com/v1/gfycats/search?search_text=little%20caprice&count=150&start=300".equalsIgnoreCase(doc.location()));
+    /**
+     * Rips Redgif tags
+     * @throws IOException
+     */
+    @Test
+    public void testRedgifsTags() throws IOException, URISyntaxException {
+        RedgifsRipper ripper  = new RedgifsRipper(new URI("https://www.redgifs.com/gifs/animation,sfw,funny?order=best&tab=gifs").toURL());
+        testRipper(ripper);
     }
 
     @Test


### PR DESCRIPTION
# Category
* [x] a bug fix (Fixes #180, fixes #108 )

# Description
* Fix RedGifs ripper.
* Add support for both tags and search urls.
* Add support for urls with sort order.
* Add support for single link galleries with multiple images.
* Use single token for all rips in an app session.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
