### PR TITLE
Fix Imgur ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 /**'
  * For ripping delicious albums off the interwebz.
+ * @deprecated Use AbstractHTMLRipper instead.
  */
 public abstract class AlbumRipper extends AbstractRipper {
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,12 +22,12 @@ import org.jsoup.nodes.Element;
 import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 
-import com.rarchives.ripme.ripper.AlbumRipper;
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 
-public class ImgurRipper extends AlbumRipper {
+public class ImgurRipper extends AbstractHTMLRipper {
 
     private static final String DOMAIN = "imgur.com",
                                 HOST   = "imgur";
@@ -73,6 +74,22 @@ public class ImgurRipper extends AlbumRipper {
             return false;
         }
         return true;
+    }
+
+    @Override
+    protected String getDomain() {
+        return DOMAIN;
+    }
+
+    @Override
+    protected void downloadURL(URL url, int index) {
+        // No-op as we override rip() method
+    }
+
+    @Override
+    protected List<String> getURLsFromPage(Document page) {
+        // No-op as we override rip() method
+        return Arrays.asList();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -61,6 +61,7 @@ public class ImgurRipper extends AlbumRipper {
         return albumType == ALBUM_TYPE.USER;
     }
 
+    @Override
     public boolean canRip(URL url) {
         if (!url.getHost().endsWith(DOMAIN)) {
            return false;
@@ -74,6 +75,7 @@ public class ImgurRipper extends AlbumRipper {
         return true;
     }
 
+    @Override
     public URL sanitizeURL(URL url) throws MalformedURLException, URISyntaxException {
         String u = url.toExternalForm();
         if (u.indexOf('#') >= 0) {
@@ -85,6 +87,7 @@ public class ImgurRipper extends AlbumRipper {
         return new URI(u).toURL();
     }
 
+    @Override
     public String getAlbumTitle(URL url) throws MalformedURLException {
         String gid = null;
         try {
@@ -468,7 +471,7 @@ public class ImgurRipper extends AlbumRipper {
         Pattern p;
         Matcher m;
 
-        p = Pattern.compile("^https?://(www\\.|m\\.)?imgur\\.com/(a|gallery)/([a-zA-Z0-9]{5,}).*$");
+        p = Pattern.compile("^https?://(?:www\\.|m\\.)?imgur\\.com/gallery/(?:(?:[a-zA-Z0-9]*/)?.*-)?([a-zA-Z0-9]+)$");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             // Imgur album or gallery
@@ -477,7 +480,7 @@ public class ImgurRipper extends AlbumRipper {
             this.url = new URI("http://imgur.com/a/" + gid).toURL();
             return gid;
         }
-        p = Pattern.compile("^https?://(www\\.|m\\.)?imgur\\.com/(a|gallery|t)/[a-zA-Z0-9]*/([a-zA-Z0-9]{5,}).*$");
+        p = Pattern.compile("^https?://(?:www\\.|m\\.)?imgur\\.com/(?:a|t)/(?:(?:[a-zA-Z0-9]*/)?.*-)?([a-zA-Z0-9]+).*$");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             // Imgur album or gallery

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -231,16 +231,18 @@ public class ImgurRipper extends AbstractHTMLRipper {
             stopCheck();
             Path saveAs = workingDir.toPath();
             if (subdirectory != null && !subdirectory.equals("")) {
-                saveAs.resolve(subdirectory);
+                saveAs = saveAs.resolve(subdirectory);
             }
             if (!Files.exists(saveAs)) {
                 Files.createDirectory(saveAs);
             }
             index += 1;
+            var imgPath = imgurImage.getSaveAs().replaceAll("\\?\\d", "");
             if (Utils.getConfigBoolean("download.save_order", true)) {
-                saveAs.resolve(String.format("%03d_", index));
+                saveAs = saveAs.resolve(String.format("%03d_%s", index, imgPath));
+            } else {
+                saveAs = saveAs.resolve(imgPath);
             }
-            saveAs = saveAs.resolve(imgurImage.getSaveAs().replaceAll("\\?\\d", ""));
             addURLToDownload(imgurImage.url, saveAs);
         }
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -255,8 +255,6 @@ public class ImgurRipper extends AbstractHTMLRipper {
         LOGGER.info("    Retrieving " + strUrl);
         Document doc = getAlbumData("https://api.imgur.com/3/album/" + strUrl.split("/a/")[1]);
         // Try to use embedded JSON to retrieve images
-        LOGGER.info(Jsoup.clean(doc.body().toString(), Safelist.none()));
-
             try {
                 JSONObject json = new JSONObject(Jsoup.clean(doc.body().toString(), Safelist.none()));
                 JSONArray jsonImages = json.getJSONObject("data").getJSONArray("images");
@@ -427,7 +425,7 @@ public class ImgurRipper extends AbstractHTMLRipper {
                 for (int i = 0; i < images.length(); i++) {
                     imagesFound++;
                     JSONObject image = images.getJSONObject(i);
-                    String imageUrl = "http://i.imgur.com/" + image.getString("hash") + image.getString("ext");
+                    String imageUrl = "https://i.imgur.com/" + image.getString("hash") + image.getString("ext");
                     String prefix = "";
                     if (Utils.getConfigBoolean("download.save_order", true)) {
                         prefix = String.format("%03d_", imagesFound);
@@ -497,7 +495,7 @@ public class ImgurRipper extends AbstractHTMLRipper {
             // Imgur album or gallery
             albumType = ALBUM_TYPE.ALBUM;
             String gid = m.group(m.groupCount());
-            this.url = new URI("http://imgur.com/a/" + gid).toURL();
+            this.url = new URI("https://imgur.com/a/" + gid).toURL();
             return gid;
         }
         // Match urls with path /a
@@ -507,7 +505,7 @@ public class ImgurRipper extends AbstractHTMLRipper {
             // Imgur album or gallery
             albumType = ALBUM_TYPE.ALBUM;
             String gid = m.group(m.groupCount());
-            this.url = new URI("http://imgur.com/a/" + gid).toURL();
+            this.url = new URI("https://imgur.com/a/" + gid).toURL();
             return gid;
         }
         p = Pattern.compile("^https?://([a-zA-Z0-9\\-]{4,})\\.imgur\\.com/?$");
@@ -563,7 +561,7 @@ public class ImgurRipper extends AbstractHTMLRipper {
             albumType = ALBUM_TYPE.ALBUM;
             String subreddit = m.group(m.groupCount() - 1);
             String gid = m.group(m.groupCount());
-            this.url = new URI("http://imgur.com/r/" + subreddit + "/" + gid).toURL();
+            this.url = new URI("https://imgur.com/r/" + subreddit + "/" + gid).toURL();
             return "r_" + subreddit + "_" + gid;
         }
         p = Pattern.compile("^https?://(i\\.|www\\.|m\\.)?imgur\\.com/([a-zA-Z0-9]{5,})$");

--- a/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
+++ b/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
@@ -17,10 +17,11 @@ public class ContextActionProtections {
         try {
             String clipboardContent = (String) transferable.getTransferData(DataFlavor.stringFlavor);
 
+            // TODO check if commenting this causes regression
             // Limit the pasted content to 96 characters
-            if (clipboardContent.length() > 96) {
-                clipboardContent = clipboardContent.substring(0, 96);
-            }
+            // if (clipboardContent.length() > 96) {
+            //     clipboardContent = clipboardContent.substring(0, 96);
+            // }
             // Set the text in the JTextField
             textComponent.setText(clipboardContent);
         } catch (UnsupportedFlavorException | IOException unable_to_modify_text_on_paste) {

--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -45,20 +45,8 @@ public class RipUtils {
                 logger.error("[!] Exception while loading album " + url, e);
             }
             return result;
-        }
-        else if (url.getHost().endsWith("imgur.com") && url.toExternalForm().contains(",")) {
-            // Imgur image series.
-            try {
-                logger.debug("Fetching imgur series at " + url);
-                ImgurRipper.ImgurAlbum imgurAlbum = ImgurRipper.getImgurSeries(url);
-                for (ImgurRipper.ImgurImage imgurImage : imgurAlbum.images) {
-                    logger.debug("Got imgur image: " + imgurImage.url);
-                    result.add(imgurImage.url);
-                }
-            } catch (IOException e) {
-                logger.error("[!] Exception while loading album " + url, e);
-            }
-        }  else if (url.getHost().endsWith("i.imgur.com") && url.toExternalForm().contains("gifv")) {
+        } 
+        else if (url.getHost().endsWith("i.imgur.com") && url.toExternalForm().contains("gifv")) {
             // links to imgur gifvs
             try {
                 result.add(new URI(url.toExternalForm().replaceAll(".gifv", ".mp4")).toURL());

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
@@ -27,6 +27,8 @@ public class ImgurRipperTest extends RippersTest {
         failURLs.add(new URI("http://i.imgur.com/").toURL());
         failURLs.add(new URI("http://imgur.com/image.jpg").toURL());
         failURLs.add(new URI("http://i.imgur.com/image.jpg").toURL());
+        // Imgur seems not to support URLs with lists of images anymore.
+        failURLs.add(new URI("http://imgur.com/758qD43,C6iVJex,bP7flAu,J3l85Ri,1U7fhu5,MbuAUCM,JF4vOXQ").toURL());
         for (URL url : failURLs) {
             try {
                 new ImgurRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
@@ -5,8 +5,6 @@ import com.rarchives.ripme.ripper.rippers.ImgurRipper.ImgurAlbum;
 import com.rarchives.ripme.utils.RipUtils;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -40,23 +38,23 @@ public class ImgurRipperTest extends RippersTest {
     }
 
     @Test
-    @Tag("flaky")
     public void testImgurAlbums() throws IOException, URISyntaxException {
         List<URL> contentURLs = new ArrayList<>();
         // URLs that should return more than 1 image
-        //contentURLs.add(new URI("http://imgur.com/a/dS9OQ#0").toURL()); // Horizontal layout
-        //contentURLs.add(new URI("http://imgur.com/a/YpsW9#0").toURL()); // Grid layout
-        contentURLs.add(new URI("http://imgur.com/a/WxG6f/layout/vertical#0").toURL());
-        contentURLs.add(new URI("http://imgur.com/a/WxG6f/layout/horizontal#0").toURL());
-        contentURLs.add(new URI("http://imgur.com/a/WxG6f/layout/grid#0").toURL());
-        contentURLs.add(new URI("http://imgur.com/gallery/FmP2o").toURL()); // Gallery URL
-        // Imgur seems not to support URLs with lists of images anymore.
-        // contentURLs.add(new
-        // URL("http://imgur.com/758qD43,C6iVJex,bP7flAu,J3l85Ri,1U7fhu5,MbuAUCM,JF4vOXQ"));
+        contentURLs.add(new URI("http://imgur.com/gallery/FmP2o").toURL()); 
+        // URLs with /gallery path
+        contentURLs.add(new URI("http://imgur.com/gallery/nAl13J6").toURL()); 
+        contentURLs.add(new URI("https://imgur.com/gallery/another-brendan-fraser-reaction-from-bedazzled-intergalactic-quality-nAl13J6").toURL()); 
+        // URLs with /a path
+        contentURLs.add(new URI("http://imgur.com/a/G058j5F").toURL()); 
+        contentURLs.add(new URI("https://imgur.com/a/thanks-batman-G058j5F").toURL()); 
+        contentURLs.add(new URI("https://imgur.com/a/thanks-batman-G058j5F/layout/grid#0").toURL()); 
+        contentURLs.add(new URI("https://imgur.com/a/G058j5F/layout/grid#0").toURL()); 
+        contentURLs.add(new URI("https://imgur.com/a/G058j5F/layout/horizontal#0").toURL()); 
         // Sometimes hangs up
         // contentURLs.add(new URI("http://imgur.com/r/nsfw_oc/top/all").toURL());
-        // contentURLs.add(new URI("http://imgur.com/a/bXQpH").toURL()); // Album with
-        // titles/descriptions
+        // Album with titles/descriptions
+        contentURLs.add(new URI("http://imgur.com/a/bXQpH").toURL()); 
         for (URL url : contentURLs) {
             ImgurRipper ripper = new ImgurRipper(url);
             testRipper(ripper);
@@ -64,7 +62,21 @@ public class ImgurRipperTest extends RippersTest {
     }
 
     @Test
-    @Disabled("test or ripper broken")
+    public void testImgurUserAccount() throws IOException, URISyntaxException {
+        List<String> contentURLs = new ArrayList<>();
+        // URL with albums
+        contentURLs.add("https://RockStarBrew.imgur.com");
+        // New URL format
+        contentURLs.add("https://imgur.com/user/RockStarBrew/");
+        // And URL with images 
+        contentURLs.add("https://imgur.com/user/counter2strike");
+        for (var url : contentURLs) {
+            ImgurRipper ripper = new ImgurRipper(new URI(url).toURL());
+            testRipper(ripper);
+        }
+    }
+
+    @Test
     public void testImgurSingleImage() throws IOException, URISyntaxException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URI("http://imgur.com/qbfcLyG").toURL()); // Single image URL
@@ -91,8 +103,8 @@ public class ImgurRipperTest extends RippersTest {
 
     @Test
     public void testImgurVideoFromGetFilesFromURL() throws Exception {
-        List<URL> urls = RipUtils.getFilesFromURL(new URI("https://i.imgur.com/4TtwxRN.gifv").toURL());
-        Assertions.assertEquals("https://i.imgur.com/4TtwxRN.mp4", urls.get(0).toExternalForm());
+        List<URL> urls = RipUtils.getFilesFromURL(new URI("https://i.imgur.com/7qoW0Mo.gifv").toURL());
+        Assertions.assertEquals("https://i.imgur.com/7qoW0Mo.mp4", urls.get(0).toExternalForm());
     }
 
     /*


### PR DESCRIPTION
### Java version
openjdk version "21.0.4" 2024-07-16
OpenJDK Runtime Environment (build 21.0.4+7-Ubuntu-1ubuntu220.04)
OpenJDK 64-Bit Server VM (build 21.0.4+7-Ubuntu-1ubuntu220.04, mixed mode, sharing)

### Check for regression
* #161 Removed 96 character limit. Check if it still occurs. I think long error lines resize the GUI( needs to be tested). 
---

# Category
This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fixes #191)

# Description
* Fix imgur ripper for galleries, single images and user accounts. 
* Add support for new gallery and user URLs. Regex101 can be used to dissect the new regex.
* Remove unsupported `series of images` code. 
* Replace imgur's usage of `AlbumRipper` with `AbstractHTMLRipper`.
* Deprecate `AlbumRipper`.
* Fix imgur prefixing for albums.
* Fix imgur subfolder creation for user albums.
* Add tests for new URLs.
* Remove 96 char limit for pasted URLs as it is not reproducible anymore. 

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
