### PR TITLE
Coomer.party Ripper Add Next Page Download Functionality

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -1,6 +1,7 @@
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractJSONRipper;
+import com.rarchives.ripme.ripper.rippers.ArtStationRipper.URL_TYPE;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 
@@ -12,6 +13,8 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +39,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     private static final String KEY_FILE = "file";
     private static final String KEY_PATH = "path";
     private static final String KEY_ATTACHMENTS = "attachments";
+
+    private Integer pageCount = 0;
+    
 
     // One of "onlyfans" or "fansly", but might have others in future?
     private final String service;
@@ -94,6 +100,24 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
         wrapperObject.put(KEY_WRAPPER_JSON_ARRAY, jsonArray);
         return wrapperObject;
     }
+
+    @Override
+    protected JSONObject getNextPage(JSONObject doc) throws IOException, URISyntaxException {
+        pageCount = pageCount + 1; 
+        Integer offset = 50 * pageCount;
+        String apiUrl = String.format("https://coomer.su/api/v1/%s/user/%s?o=%d", service, user, offset);
+        String jsonArrayString = Http.url(apiUrl)
+                .ignoreContentType()
+                .response()
+                .body();
+        JSONArray jsonArray = new JSONArray(jsonArrayString);
+
+        // Ideally we'd just return the JSONArray from here, but we have to wrap it in a JSONObject
+        JSONObject wrapperObject = new JSONObject();
+        wrapperObject.put(KEY_WRAPPER_JSON_ARRAY, jsonArray);
+        return wrapperObject;
+    }
+
 
     @Override
     protected List<String> getURLsFromJSON(JSONObject json) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [] a bug fix (Fix #...)
* [ ] a new Ripper
* [X] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
The original coomer.party ripper never implemented anything beyond getting the first page, and with coomer.party seemingly on it's last legs, doing a quick fix to be able to rescue it's content seemed prudent. 

This doesn't do much other than add the GetNextPage override, track the pagination, and cleans up the code so it wouldn't be repeated. 

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
