### PR TITLE
E-hentai ripper not working fix.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
@@ -177,7 +177,7 @@ public class EHentaiRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
-        Elements thumbs = page.select("#gdt > .gdtm a");
+        Elements thumbs = page.select("#gdt > a");
         // Iterate over images on page
         for (Element thumb : thumbs) {
             imageURLs.add(thumb.attr("href"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #206 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description
Fixed changed selector for E-Hentai ripper

# Testing
Manually downloaded a couple of galleries.