### PR TITLE
App does not open set to most recently used language.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -570,7 +570,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configLogLevelCombobox = new JComboBox<>(
                 new String[] { "Log level: Error", "Log level: Warn", "Log level: Info", "Log level: Debug" });
         configSelectLangComboBox = new JComboBox<>(Utils.getSupportedLanguages());
-        configSelectLangComboBox.setSelectedItem(Utils.getSelectedLanguage());
+        configSelectLangComboBox.setSelectedItem(Utils.getConfigString("lang", Utils.getSelectedLanguage()));
         configLogLevelCombobox.setSelectedItem(Utils.getConfigString("log.level", "Log level: Debug"));
         setLogLevel(configLogLevelCombobox.getSelectedItem().toString());
         configSaveDirLabel = new JLabel();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #208 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description

App was not detecting the language saved in config file and using it on start.

# Testing
Reopened app multiple times and changed languages, issue no longer reproducible.