### PR TITLE
Removed unnecessary new Java syntax

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/VidearnRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/VidearnRipper.java
@@ -57,7 +57,7 @@ public class VidearnRipper extends VideoRipper {
         if (mp4s.isEmpty()) {
             throw new IOException("Could not find files at " + url);
         }
-        String vidUrl = mp4s.getFirst();
+        String vidUrl = mp4s.get(0);
         addURLToDownload(new URI(vidUrl).toURL(), HOST + "_" + getGID(this.url));
         waitForThreads();
     }


### PR DESCRIPTION
This line breaks Java 17 compatibility, so I fixed it.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

We don't need to call getFirst() when we can just call get(0) since it's the same thing. Might as well keep Java 17 compatibility since everything else in this repo is Java 17 compatible.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
